### PR TITLE
XIVY-8697 Fix test for change embedded sub type

### DIFF
--- a/integration/standalone/webtests/tool-bar/type-palette.spec.ts
+++ b/integration/standalone/webtests/tool-bar/type-palette.spec.ts
@@ -52,7 +52,7 @@ test.describe('tool bar - BPMN type palette', () => {
     await expect(user).toBeVisible();
     await expect(embedded).toBeHidden();
 
-    await openTypePalette(page, user);
+    await openTypePalette(page, false);
     await toolButtons.locator('text=Sub').click();
     await expect(embedded).toBeVisible();
     await expect(user).toBeHidden();
@@ -64,17 +64,16 @@ test.describe('tool bar - BPMN type palette', () => {
     await clickQuickActionStartsWith(page, 'Wrap');
   }
 
-  async function openTypePalette(page: Page, element?: Locator): Promise<Locator> {
+  async function openTypePalette(page: Page, select = true): Promise<Locator> {
     const paletteBody = page.locator(PALETTE_BODY);
     const dynamicTools = page.locator('.dynamic-tools');
     const typePaletteBtn = dynamicTools.locator('i[title$=Type]');
-    await expect(dynamicTools).toBeHidden();
 
-    if (element) {
-      await element.click();
-    } else {
+    if (select) {
+      await expect(dynamicTools).toBeHidden();
       await page.locator(embeddedSelector).click();
     }
+
     await expect(dynamicTools).toBeVisible();
     await expect(typePaletteBtn).toBeVisible();
     await typePaletteBtn.click();


### PR DESCRIPTION
Since we not longer change the id with the type change, the selection of the embedded sub stays active. This means there is no need to reselect it in the test to change the type again