### PR TITLE
XIVY-9009 Improve edit label

### DIFF
--- a/editor/css/colors.css
+++ b/editor/css/colors.css
@@ -42,7 +42,7 @@
   --glsp-execution-failed: #ff796f;
   --glsp-execution-stopped: #cca700;
 
-  --glsp-inline-label-background: rgba(0, 0, 0, 0.18);
+  --glsp-inline-label-background: rgba(245, 245, 245, 0.9);
 }
 
 html[data-theme='dark'] body {
@@ -67,5 +67,5 @@ html[data-theme='dark'] body {
   --glsp-breakpoint-condition: #cca700;
   --glsp-breakpoint-hover: rgba(244, 135, 113, 0.5);
 
-  --glsp-inline-label-background: rgba(255, 255, 255, 0.18);
+  --glsp-inline-label-background: rgba(32, 32, 32, 0.9);
 }

--- a/editor/css/inline-label.css
+++ b/editor/css/inline-label.css
@@ -3,27 +3,13 @@
   background: var(--glsp-inline-label-background);
   color: var(--glsp-foreground);
   border-radius: 5px;
-  border: 0;
   width: 99%;
   height: 99%;
+  box-shadow: var(--glsp-box-shadow);
 }
 
 .label-edit input:focus,
 .label-edit textarea:focus {
   outline: none;
   outline-offset: 0px;
-}
-
-.label-edit {
-  border-left: 1px dotted gray;
-}
-
-.label-edit.validation-warning {
-  color: var(--glsp-warning-foreground);
-  border-left: 1px dotted var(--glsp-warning-foreground);
-}
-
-.label-edit.validation-error {
-  color: var(--glsp-error-foreground);
-  border-left: 1px dotted var(--glsp-error-foreground);
 }

--- a/editor/src/diagram/model.ts
+++ b/editor/src/diagram/model.ts
@@ -301,7 +301,7 @@ export class MulitlineEditLabel extends SLabel implements EditableLabel {
 
   readonly isMultiLine = true;
   get editControlDimension(): Dimension {
-    return { width: Math.max(this.bounds.width + 25, 50), height: Math.max(this.bounds.height, 16) };
+    return { width: Math.max(this.bounds.width + 25, 144), height: Math.max(this.bounds.height, 44) };
   }
 
   get editControlPositionCorrection(): Point {
@@ -311,7 +311,7 @@ export class MulitlineEditLabel extends SLabel implements EditableLabel {
 
 export class RotateLabel extends MulitlineEditLabel {
   get editControlDimension(): Dimension {
-    return { width: this.bounds.height, height: this.bounds.width };
+    return { width: Math.min(this.bounds.height + 25, 144), height: Math.max(this.bounds.width, 44) };
   }
 }
 


### PR DESCRIPTION
XIVY-9009 Improve edit label ui

Whished by bb:
- Ui to small for arcs, events, gateways
- Ui to big for pools/lanes
- Ui to much transparent