### PR TITLE
XIVY-9214 Unify options text and shortcut replacement

### DIFF
--- a/editor/src/connector/actions.ts
+++ b/editor/src/connector/actions.ts
@@ -98,13 +98,13 @@ class ReconnectEdgeQuickAction implements QuickAction {
   constructor(
     public readonly edge: SEdge,
     public readonly icon = StreamlineIcons.Reconnect,
-    public readonly title = 'Reconnect (C)',
+    public readonly title = 'Reconnect (R)',
     public readonly location = QuickActionLocation.Right,
     public readonly sorting = 'A',
     public readonly action = QuickActionTriggerEdgeCreationAction.create(edge.type, edge.sourceId, {
       edgeId: edge.id,
       reconnect: true
     }),
-    public readonly shortcut: KeyCode = 'KeyC'
+    public readonly shortcut: KeyCode = 'KeyR'
   ) {}
 }

--- a/editor/src/ui-tools/tool-bar/options/options-menu-ui.ts
+++ b/editor/src/ui-tools/tool-bar/options/options-menu-ui.ts
@@ -53,7 +53,7 @@ export class ToolBarOptionsMenu implements Menu {
     const header = createElement('div', ['tool-bar-options-header']);
     header.appendChild(createIcon(['si', `si-${StreamlineIcons.Settings}`]));
     const label = document.createElement('label');
-    label.textContent = 'Settings';
+    label.textContent = 'Options';
     header.appendChild(label);
     return header;
   }

--- a/editor/tests/quick-action/quick-action-ui.spec.ts
+++ b/editor/tests/quick-action/quick-action-ui.spec.ts
@@ -34,7 +34,7 @@ describe('QuickActionUi', () => {
     assertQuickAction(3, 'Bend (B)', `si si-${StreamlineIcons.Bend}`);
     assertQuickAction(4, 'Edit Label (L)', `si si-${StreamlineIcons.Label}`);
     assertQuickAction(5, 'Select color', `si si-${StreamlineIcons.Color}`);
-    assertQuickAction(6, 'Reconnect (C)', `si si-${StreamlineIcons.Reconnect}`);
+    assertQuickAction(6, 'Reconnect (R)', `si si-${StreamlineIcons.Reconnect}`);
   });
 
   it('ui is rendered for activity element', () => {

--- a/integration/standalone/webtests/key-listener/quick-action.spec.ts
+++ b/integration/standalone/webtests/key-listener/quick-action.spec.ts
@@ -37,7 +37,7 @@ test.describe('key listener - quick action shortcuts', () => {
     await expect(connectorFeedback).toBeHidden();
 
     await connector.click();
-    await pressQuickActionShortcut(page, 'C');
+    await pressQuickActionShortcut(page, 'R');
     await expect(connector).toBeVisible();
     await expect(connectorFeedback).toBeVisible();
   });


### PR DESCRIPTION
* Options:
![image](https://user-images.githubusercontent.com/93579455/188646779-fd9b1ed6-1d9c-40b9-bc9b-117cdbfd9262.png)

* KeyC is already used to open data class