### PR TITLE
XIVY-9589 Fix color overflow in quick action menu

### DIFF
--- a/editor/css/menu.css
+++ b/editor/css/menu.css
@@ -105,6 +105,8 @@
   align-items: center;
   padding-right: 0.8rem;
   cursor: pointer;
+  word-break: break-word;
+  overflow: hidden;
 }
 .bar-menu-items .menu-item.focus {
   background: var(--glsp-bar-menu-item-hover);


### PR DESCRIPTION
Bug:
![color-bug](https://user-images.githubusercontent.com/42733123/192540496-9d202027-da57-4f9a-8f92-6b5527316d5c.png)

Fix:
![image](https://user-images.githubusercontent.com/42733123/192540374-a657b420-380c-490d-a98a-e2cb6d5d3cd9.png)
