### PR TITLE
XIVY-9716 Start quick action removes selection

### DIFF
--- a/editor/src/ui-tools/quick-action/quick-action-ui.ts
+++ b/editor/src/ui-tools/quick-action/quick-action-ui.ts
@@ -16,6 +16,7 @@ import {
   SChildElement,
   SConnectableElement,
   SEdge,
+  SelectAllAction,
   SetUIExtensionVisibilityAction,
   SModelElement,
   SModelRoot,
@@ -253,6 +254,9 @@ export class QuickActionUI extends AbstractUIExtension implements IActionHandler
     const actions = [quickAction.action];
     if (!quickAction.letQuickActionsOpen) {
       actions.push(SetUIExtensionVisibilityAction.create({ extensionId: QuickActionUI.ID, visible: false }));
+    }
+    if (quickAction.removeSelection) {
+      actions.push(SelectAllAction.create(false));
     }
     button.onclick = () => this.triggerQuickActionBtn(button, actions);
     return button;

--- a/editor/src/ui-tools/quick-action/quick-action.ts
+++ b/editor/src/ui-tools/quick-action/quick-action.ts
@@ -71,6 +71,7 @@ export interface QuickAction {
   letQuickActionsOpen?: boolean;
   readonlySupport?: boolean;
   shortcut?: KeyCode;
+  removeSelection?: boolean;
 }
 
 class DeleteQuickAction implements QuickAction {

--- a/integration/eclipse/webview/src/editor-action/actions.ts
+++ b/integration/eclipse/webview/src/editor-action/actions.ts
@@ -28,9 +28,9 @@ class StartProcessQuickAction implements QuickAction {
     public readonly location = QuickActionLocation.Left,
     public readonly sorting = 'A',
     public readonly action = StartProcessAction.create(elementId),
-    public readonly letQuickActionsOpen = true,
     public readonly readonlySupport = true,
-    public readonly shortcut: KeyCode = 'KeyX'
+    public readonly shortcut: KeyCode = 'KeyX',
+    public readonly removeSelection = true
   ) {}
 }
 


### PR DESCRIPTION
- As the quick action should go away, but also appear after another click on the start, I have to remove the selection.