### PR TITLE
XIVY-9724 Fix move element to negative area

### DIFF
--- a/editor/src/lanes/model.ts
+++ b/editor/src/lanes/model.ts
@@ -4,6 +4,7 @@ import {
   hoverFeedbackFeature,
   isBoundsAware,
   isSelectable,
+  isSelected,
   SChildElement,
   Selectable,
   SModelElement,
@@ -16,6 +17,10 @@ export interface LaneResizable extends BoundsAware, Selectable {}
 
 export function isLaneResizable(element: SModelElement): element is SParentElement & LaneResizable {
   return isBoundsAware(element) && isSelectable(element) && element instanceof SParentElement && element.hasFeature(laneResizeFeature);
+}
+
+export function isSelectedLane(element: SModelElement): element is SParentElement & LaneResizable {
+  return isLaneResizable(element) && isSelected(element);
 }
 
 export enum LaneResizeHandleLocation {


### PR DESCRIPTION
- Fix the element was moved into the negative if the cursor left the editor window
- Fix remove red border (movement restrictor feedback) after the element is back in the old position
- Hide quick-action bar on move/resize lane
- Fix no ChangeBoundsOperation if lane is selected but element dragged to negative