### PR TITLE
Fix webtests to run on mac > R10

### DIFF
--- a/integration/standalone/glsp-test-project/processes/jump.p.json
+++ b/integration/standalone/glsp-test-project/processes/jump.p.json
@@ -25,9 +25,9 @@
     }, {
       "id" : "f3",
       "type" : "TriggerCall",
-      "name" : "jump",
+      "name" : "info",
       "config" : {
-        "processCall" : "jump:triggerStart()"
+        "processCall" : "info:start()"
       },
       "visual" : {
         "at" : { "x" : 544, "y" : 64 }
@@ -56,24 +56,5 @@
         "at" : { "x" : 224, "y" : 64 }
       },
       "connect" : { "id" : "f8", "to" : "f5" }
-    }, {
-      "id" : "f9",
-      "type" : "RequestStart",
-      "name" : "triggerStart.ivp",
-      "config" : {
-        "callSignature" : "triggerStart",
-        "outLink" : "triggerStart.ivp",
-        "triggerEnabled" : true
-      },
-      "visual" : {
-        "at" : { "x" : 96, "y" : 224 }
-      },
-      "connect" : { "id" : "f11", "to" : "f10" }
-    }, {
-      "id" : "f10",
-      "type" : "TaskEnd",
-      "visual" : {
-        "at" : { "x" : 288, "y" : 224 }
-      }
     } ]
 }

--- a/integration/standalone/webtests/diagram-util.ts
+++ b/integration/standalone/webtests/diagram-util.ts
@@ -28,12 +28,16 @@ export async function resetSelection(page: Page): Promise<void> {
   await expect(page.locator('g.selected')).toHaveCount(0);
 }
 
-export function getCtrl(browserName: string): string {
-  if (browserName === 'webkit') {
+export function getCtrl(browserName?: string): string {
+  if (browserName === 'webkit' || isMac()) {
     return 'Meta';
   } else {
     return 'Control';
   }
+}
+
+export function isMac(): boolean {
+  return process.platform === 'darwin';
 }
 
 export async function cleanDiagram(page: Page): Promise<void> {

--- a/integration/standalone/webtests/diagram/diagram.spec.ts
+++ b/integration/standalone/webtests/diagram/diagram.spec.ts
@@ -20,6 +20,7 @@ test.describe('diagram', () => {
     await toolBarMenu.locator('.menu-item:has-text("User Dialog")').click();
     await assertNegativeArea(page, true);
     await page.locator('.sprotty-graph').click({ position: { x: 100, y: 100 } });
+    await expect(page.locator('.dialogCall')).toBeVisible();
     await assertNegativeArea(page, false);
   });
 
@@ -69,7 +70,7 @@ test.describe('diagram', () => {
     if (visible) {
       await expect(negativeArea).toHaveCount(2);
     } else {
-      await expect(negativeArea).toBeHidden();
+      await expect(negativeArea).not.toHaveCount(2);
     }
   }
 });

--- a/integration/standalone/webtests/key-listener/quick-action.spec.ts
+++ b/integration/standalone/webtests/key-listener/quick-action.spec.ts
@@ -1,5 +1,5 @@
 import { expect, Locator, Page, test } from '@playwright/test';
-import { resetSelection, multiSelect, startSelector, endSelector, embeddedSelector } from '../diagram-util';
+import { resetSelection, multiSelect, startSelector, endSelector, embeddedSelector, getCtrl } from '../diagram-util';
 import { gotoRandomTestProcessUrl } from '../process-editor-url-util';
 import { QUICK_ACTION_BTN } from '../quick-actions/quick-actions-util';
 
@@ -42,7 +42,7 @@ test.describe('key listener - quick action shortcuts', () => {
     await expect(connectorFeedback).toBeVisible();
   });
 
-  test('label edit', async ({ page, browserName }) => {
+  test('label edit', async ({ page }) => {
     const label = page.locator('.label-edit textarea');
     const start = page.locator(startSelector);
     await expect(start.locator('.sprotty-label div')).toHaveText('start.ivp');
@@ -51,7 +51,7 @@ test.describe('key listener - quick action shortcuts', () => {
     await start.click();
     await pressQuickActionShortcut(page, 'L');
     await expect(label).toBeVisible();
-    await page.keyboard.press('Control+A');
+    await page.keyboard.press(`${getCtrl()}+A`);
     await page.keyboard.type('test label');
     await page.keyboard.press('Enter');
     await expect(start.locator('.sprotty-label div')).toHaveText('test label');

--- a/integration/standalone/webtests/key-listener/undo-redo.spec.ts
+++ b/integration/standalone/webtests/key-listener/undo-redo.spec.ts
@@ -1,5 +1,5 @@
 import { expect, Page, test } from '@playwright/test';
-import { assertPosition, assertPositionIsNot, getCtrl, getPosition, startSelector } from '../diagram-util';
+import { assertPosition, assertPositionIsNot, getCtrl, getPosition, isMac, startSelector } from '../diagram-util';
 import { gotoRandomTestProcessUrl } from '../process-editor-url-util';
 
 test.describe('key listener - undo redo', () => {
@@ -43,7 +43,7 @@ async function undo(page: Page, browserName: string): Promise<void> {
 
 async function redo(page: Page, browserName: string): Promise<void> {
   let redoKey = 'Y';
-  if (browserName === 'webkit') {
+  if (browserName === 'webkit' || isMac()) {
     redoKey = 'Shift+Z';
   }
   await page.keyboard.press(`${getCtrl(browserName)}+${redoKey}`);

--- a/integration/standalone/webtests/navigation/jump-to-external-target.spec.ts
+++ b/integration/standalone/webtests/navigation/jump-to-external-target.spec.ts
@@ -12,13 +12,13 @@ test.describe('Jump to external target', () => {
   test('trigger process', async ({ page }) => {
     await page.goto(jumpProcess());
     const trigger = page.locator('#sprotty_183E4A356E771204-f3');
-    await jumpToExternalTargetAndAssert(page, trigger, '183E4A356E771204', '183E4A356E771204-f9');
+    await jumpToExternalTargetAndAssert(page, trigger, '1842D6FBB6A107AB', '1842D6FBB6A107AB-f0');
   });
 
   test('sub process', async ({ page }) => {
     await page.goto(jumpProcess());
-    const trigger = page.locator('#sprotty_183E4A356E771204-f6');
-    await jumpToExternalTargetAndAssert(page, trigger, '183E4A4179C3C69B', '183E4A4179C3C69B-f0');
+    const callSub = page.locator('#sprotty_183E4A356E771204-f6');
+    await jumpToExternalTargetAndAssert(page, callSub, '183E4A4179C3C69B', '183E4A4179C3C69B-f0');
   });
 
   async function jumpToExternalTargetAndAssert(page: Page, element: Locator, expectedProcessPid: string, expectedElementPid: string): Promise<void> {

--- a/integration/standalone/webtests/process-editor-url-util.ts
+++ b/integration/standalone/webtests/process-editor-url-util.ts
@@ -14,15 +14,6 @@ function serverUrl(): string {
 }
 
 export async function gotoRandomTestProcessUrl(page: Page, urlQueryParam = ''): Promise<void> {
-  // Log websocket communications:
-  if (process.env.CI) {
-    page.on('websocket', ws => {
-      console.log(`WebSocket opened: ${ws.url()}>`);
-      ws.on('framesent', event => console.log('>> sent: ' + event.payload));
-      ws.on('framereceived', event => console.log('<< recv: ' + event.payload));
-      ws.on('close', () => console.log('WebSocket closed'));
-    });
-  }
   await page.goto(randomTestProcessUrl() + urlQueryParam);
   const start = page.locator(startSelector);
   // wait for start element, give a reload if was not visible the first time


### PR DESCRIPTION
Same as on master: https://github.com/axonivy/process-editor-client/pull/362

- Make webtests runnable on mac (fix commands like copy paste)
- Remove ws log
- Stabilize diagram nigative area test