### PR TITLE
XIVY-12919 Prefill eclipse index.html with content

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
 {
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": ["javascript", "typescript"],
   "search.exclude": {
@@ -39,10 +39,5 @@
   },
   "[yaml]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
-  },
-  "mochaExplorer.configFile": "configs/.mocharc.json",
-  "mochaExplorer.files": "packages/editor/tests/**/*.spec.?(ts|tsx)",
-  "mochaExplorer.env": {
-    "TS_NODE_PROJECT": "packages/editor/tsconfig.mocha.json"
   }
 }

--- a/integration/eclipse/index.html
+++ b/integration/eclipse/index.html
@@ -1,18 +1,68 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Inscription Editor for Axon Ivy Process Elements" />
-    <title>Process Editor</title>
-  </head>
 
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="sprotty" class="main-widget"></div>
-    <div id="inscription"></div>
-    <script type="module" src="/src/index.ts"></script>
-  </body>
+<head>
+  <meta charset="utf-8" />
+  <link rel="icon" href="/favicon.ico" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="theme-color" content="#000000" />
+  <meta name="description" content="Inscription Editor for Axon Ivy Process Elements" />
+  <title>Process Editor</title>
+</head>
+
+<body>
+  <noscript>You need to enable JavaScript to run this app.</noscript>
+  <div id="sprotty" class="main-widget">
+    <div class="ivy-viewport-bar" style="visibility: visible; opacity: 1;">
+      <div class="viewport-bar">
+        <div class="viewport-bar-tools" style="width: 167px; height: 36px;">
+        </div>
+      </div>
+    </div>
+    <div class="ivy-tool-bar" style="visibility: visible; opacity: 1;">
+      <div class="tool-bar-header">
+        <div class="left-buttons">
+          <span class="tool-bar-button clicked" title="Selection Tool" id="btn_default_tools"><i
+              class="ivy ivy-selection-tool"></i></span>
+          <span class="tool-bar-button" title="Marquee Tool (Shift)" id="btn_marquee_tools"><i
+              class="ivy ivy-multi-selection"></i></span>
+        </div>
+      </div>
+      <div class="tool-bar-progress-container" role="progressbar">
+        <div class="progress-bit"></div>
+      </div>
+    </div>
+    <div tabindex="0" id="ivy-glsp-process_Editor_1_15254DC87A1B183B" data-svg-metadata-api=""
+      data-svg-metadata-type="graph" style="width: 100%; height: 100%;" class="grid">
+      <svg class="sprotty-graph" style="height: 100%; width: 100%;"></svg>
+    </div>
+    <script>
+      const theme = new URLSearchParams(window.location.search).get('theme');
+      document.documentElement.dataset.theme = theme;
+    </script>
+    <style>
+      html body {
+        background-color: #fafafa;
+      }
+
+      html[data-theme="dark"] body {
+        background-color: #3c3b3a;
+      }
+
+      .tool-bar-progress-container .progress-bit {
+        background-color: var(--glsp-editor-selected, #0065ff);
+        width: 2%;
+        height: 2px;
+        animation-name: progress;
+        animation-duration: 4s;
+        animation-iteration-count: infinite;
+        transform: translateZ(0);
+        animation-timing-function: linear;
+      }
+    </style>
+  </div>
+  <div id="inscription"></div>
+  <script type="module" src="/src/index.ts"></script>
+</body>
+
 </html>

--- a/packages/editor/src/colors.css
+++ b/packages/editor/src/colors.css
@@ -49,6 +49,7 @@
 
 html body {
   color-scheme: light;
+  background-color: var(--glsp-editor-background);
 }
 
 html[data-theme='dark'] body {

--- a/packages/editor/src/diagram/diagram.css
+++ b/packages/editor/src/diagram/diagram.css
@@ -12,7 +12,7 @@ body {
 .sprotty > div:focus-visible {
   outline: none;
 }
-.sprotty svg.sprotty-graph {
+.sprotty svg:where(.sprotty-graph, .sprotty-empty) {
   border: none;
 }
 .sprotty-graph {

--- a/packages/editor/src/ui-tools/tool-bar/tool-bar.css
+++ b/packages/editor/src/ui-tools/tool-bar/tool-bar.css
@@ -4,6 +4,7 @@
   width: 100%;
   height: 48px;
   background: var(--glsp-tool-bar-bg);
+  box-shadow: var(--glsp-box-shadow);
   z-index: 10;
   container: toolbar / inline-size;
 }

--- a/process-editor-client.code-workspace
+++ b/process-editor-client.code-workspace
@@ -32,7 +32,7 @@
   "settings": {
     "editor.formatOnSave": true,
     "editor.codeActionsOnSave": {
-      "source.fixAll.eslint": true
+      "source.fixAll.eslint": "explicit"
     },
     "vitest.commandLine": "yarn --cwd packages/editor test",
     "eslint.validate": ["javascript", "typescript"],


### PR DESCRIPTION
Before:
![Screen Recording 2023-12-14 at 08 13 51](https://github.com/axonivy/process-editor-client/assets/42733123/b702badf-920c-470f-b5af-7c3cda6a5bc8)

After (without toolbar etc):
![Screen Recording 2023-12-14 at 08 09 09](https://github.com/axonivy/process-editor-client/assets/42733123/522251a0-0eb4-4be9-b559-a69d51df93ab)

After (with toolbar etc):
![Screen Recording 2023-12-14 at 08 07 28](https://github.com/axonivy/process-editor-client/assets/42733123/8e8021c1-759c-4396-b880-f87dd4003523)

Captured with built eclipse integration + Chrome + 6x CPU slowdown.
I think prefer the solution with the toolbar, but the problem here is that first an empty sprotty graph is rendered, this is also the reason why it still flaker (remove of the old preview -> render final view)