### PR TITLE
XIVY-12919 Lazy render inscription ui > R11.2

### DIFF
--- a/packages/editor/src/ui-tools/tool-bar/tool-bar.ts
+++ b/packages/editor/src/ui-tools/tool-bar/tool-bar.ts
@@ -233,9 +233,8 @@ export class ToolBar extends AbstractUIExtension implements IActionHandler, Edit
   }
 
   editModeChanged(_oldValue: string, _newValue: string): void {
-    if (_oldValue) {
-      this.actionDispatcher.dispatch(SetUIExtensionVisibilityAction.create({ extensionId: ToolBar.ID, visible: true }));
-    }
+    this.containerElement.innerHTML = '';
+    this.createHeader();
   }
 
   selectionChanged(root: Readonly<SModelRoot>, selectedElements: string[]): void {


### PR DESCRIPTION
- Do no initial load inscription ui (even if it is hidden)
- Fix readonly of toolbar (because we now faster activate the toolbar the edit mode is maybe not set to readonly, which cause that edit button are rendered, e.g. if you currently open a process in of an iar project in the Designer)

Same as on master: https://github.com/axonivy/process-editor-client/pull/445