### PR TITLE
fix test: let quick action open on edge operations

### DIFF
--- a/packages/editor/src/connector/actions.ts
+++ b/packages/editor/src/connector/actions.ts
@@ -16,6 +16,7 @@ export class StraightenEdgeQuickActionProvider extends SingleQuickActionProvider
         location: 'Middle',
         sorting: 'A',
         action: StraightenEdgeOperation.create({ elementId: element.id }),
+        letQuickActionsOpen: true,
         shortcut: 'KeyS'
       };
     }
@@ -33,6 +34,7 @@ export class AutoBendEdgeQuickActionProvider extends SingleQuickActionProvider {
         location: 'Middle',
         sorting: 'B',
         action: AutoBendEdgeOperation.create({ elementId: element.id }),
+        letQuickActionsOpen: true,
         shortcut: 'KeyB'
       };
     }
@@ -50,6 +52,7 @@ export class ReconnectEdgeQuickActionProvider extends SingleQuickActionProvider 
         location: 'Right',
         sorting: 'A',
         action: QuickActionTriggerEdgeCreationAction.create(element.type, element.sourceId, { edgeId: element.id, reconnect: true }),
+        letQuickActionsOpen: true,
         shortcut: 'KeyR'
       };
     }


### PR DESCRIPTION
do not hide quickactions after pressing shortcut

before:
https://github.com/axonivy/process-editor-client/assets/93579455/db3eb313-c4f6-476f-9fd2-a131484ce169

after:
https://github.com/axonivy/process-editor-client/assets/93579455/7cd0b21b-e1db-4855-b562-c71f8796943a

