### PR TITLE
Fix snapping and other visualization issues

### DIFF
--- a/integration/eclipse/package.json
+++ b/integration/eclipse/package.json
@@ -8,9 +8,9 @@
   "dependencies": {
     "@axonivy/process-editor": "11.9.0-next",
     "@axonivy/process-editor-inscription": "11.9.0-next",
-    "@eclipse-glsp/client": "2.1.0",
-    "@eclipse-glsp/ide": "2.1.0",
-    "@eclipse-glsp/protocol": "2.1.0"
+    "@eclipse-glsp/client": "~2.1.0",
+    "@eclipse-glsp/ide": "~2.1.0",
+    "@eclipse-glsp/protocol": "~2.1.0"
   },
   "devDependencies": {
     "@vscode/codicons": "^0.0.25",

--- a/integration/standalone/package.json
+++ b/integration/standalone/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@axonivy/process-editor": "11.9.0-next",
     "@axonivy/process-editor-inscription": "11.9.0-next",
-    "@eclipse-glsp/client": "2.1.0"
+    "@eclipse-glsp/client": "~2.1.0"
   },
   "devDependencies": {
     "@types/uuid": "^9.0.7",

--- a/integration/viewer/package.json
+++ b/integration/viewer/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@axonivy/process-editor": "11.9.0-next",
-    "@eclipse-glsp/client": "2.1.0"
+    "@eclipse-glsp/client": "~2.1.0"
   },
   "devDependencies": {
     "@types/uuid": "^9.0.7",

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@axonivy/editor-icons": "~11.3.0-next.936",
     "@axonivy/process-editor-protocol": "11.9.0-next",
-    "@eclipse-glsp/client": "2.1.0",
+    "@eclipse-glsp/client": "~2.1.0",
     "showdown": "^2.1.0",
     "toastify-js": "1.12.0"
   },

--- a/packages/editor/src/di.config.ts
+++ b/packages/editor/src/di.config.ts
@@ -40,7 +40,14 @@ import ivyLaneModule from './lanes/di.config';
 import { ivyNotificationModule } from './notification/di.config';
 import { IvyViewerOptions, defaultIvyViewerOptions } from './options';
 import ivyThemeModule from './theme/di.config';
-import { ivyChangeBoundsToolModule, ivyExportModule, ivyMarqueeSelectionToolModule, ivyNodeCreationToolModule } from './tools/di.config';
+import {
+  ivyBoundsExtensionModule,
+  ivyChangeBoundsToolModule,
+  ivyExportModule,
+  ivyHelperLineExtensionModule,
+  ivyMarqueeSelectionToolModule,
+  ivyNodeCreationToolModule
+} from './tools/di.config';
 import { IVY_TYPES } from './types';
 import ivyQuickActionModule from './ui-tools/quick-action/di.config';
 import ivyToolBarModule from './ui-tools/tool-bar/di.config';
@@ -90,6 +97,10 @@ export default function createContainer(widgetId: string, ...containerConfigurat
     ivyMarqueeSelectionToolModule,
     ivyThemeModule,
 
+    // Ivy extensions:
+    ivyHelperLineExtensionModule,
+    ivyBoundsExtensionModule,
+
     // additional configurations
     ...containerConfiguration
   );
@@ -97,6 +108,7 @@ export default function createContainer(widgetId: string, ...containerConfigurat
   // configurations
   container.bind<IvyViewerOptions>(IVY_TYPES.IvyViewerOptions).toConstantValue(defaultIvyViewerOptions());
   container.bind<IHelperLineOptions>(TYPES.IHelperLineOptions).toConstantValue({
+    alignmentEpsilon: 0, // positions must match perfectly, we already restrict movement to the grid and only use integer positions (no decimals)
     minimumMoveDelta: { x: IvyGridSnapper.GRID_X * 2, y: IvyGridSnapper.GRID_Y * 2 },
     alignmentElementFilter: element =>
       !(element instanceof LaneNode) &&

--- a/packages/editor/src/diagram/snap.ts
+++ b/packages/editor/src/diagram/snap.ts
@@ -1,4 +1,4 @@
-import { GridSnapper } from '@eclipse-glsp/client';
+import { GModelElement, GridSnapper, Point } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 
 @injectable()
@@ -9,4 +9,15 @@ export class IvyGridSnapper extends GridSnapper {
   constructor() {
     super({ x: IvyGridSnapper.GRID_X, y: IvyGridSnapper.GRID_Y });
   }
+
+  snap(delta: Point, _element: GModelElement): Point {
+    return onGrid(delta, this.grid);
+  }
+}
+
+export function onGrid(point: Point, grid: Point): Point {
+  return {
+    x: Math.trunc(point.x / grid.x) * grid.x,
+    y: Math.trunc(point.y / grid.y) * grid.y
+  };
 }

--- a/packages/editor/src/hidden.css
+++ b/packages/editor/src/hidden.css
@@ -1,4 +1,6 @@
-/* Hide label elements from the hidden rendering process to ensure during resizing we get the correct size of the elements. */
-.sprotty-hidden g[id^='sprotty_label'] {
-  display: none;
+.ghost-element.hidden {
+  display: unset;
+  width: 0;
+  height: 0;
+  visibility: hidden;
 }

--- a/packages/editor/src/tools/change-bounds-tool.ts
+++ b/packages/editor/src/tools/change-bounds-tool.ts
@@ -96,14 +96,22 @@ export class IvyFeedbackMoveMouseListener extends FeedbackMoveMouseListener {
     if (this.tool.movementRestrictor?.cssClasses) {
       for (const [elementId] of this.elementId2startPos) {
         const element = target.root.index.getById(elementId);
-        if (this.isMovementRestricted(element, this.tool.movementRestrictor.cssClasses)) {
+        if (element && this.isMovementRestricted(element, this.tool.movementRestrictor.cssClasses)) {
           this.reset(true);
+          this.tool.deregisterFeedback(this, [removeMovementRestrictionFeedback(element, this.tool.movementRestrictor)]);
           return result;
         }
       }
     }
     this.reset();
     return result;
+  }
+
+  nonDraggingMouseUp(element: GModelElement, event: MouseEvent): Action[] {
+    if (this.moveInitialized) {
+      super.nonDraggingMouseUp(element, event);
+    }
+    return [];
   }
 
   protected isMovementRestricted(target: GModelElement | undefined, restrictionClasses: string[]): boolean {

--- a/packages/editor/src/tools/di.config.ts
+++ b/packages/editor/src/tools/di.config.ts
@@ -1,19 +1,24 @@
 import {
+  DrawHelperLinesFeedbackCommand,
   ExportSvgCommand,
   ExportSvgPostprocessor,
   FeatureModule,
+  GLSPHiddenBoundsUpdater,
+  HelperLineManager,
   HideChangeBoundsToolResizeFeedbackCommand,
   SResizeHandle,
   SResizeHandleView,
   ShowChangeBoundsToolResizeFeedbackCommand,
   TYPES,
   bindAsService,
+  boundsModule,
   changeBoundsToolModule,
   configureActionHandler,
   configureCommand,
   configureView,
   elementTemplateModule,
   exportModule,
+  helperLineModule,
   nodeCreationToolModule
 } from '@eclipse-glsp/client';
 
@@ -21,6 +26,9 @@ import { TriggerNodeCreationAction } from '@eclipse-glsp/protocol';
 import { IvyMarqueeMouseTool } from '../ui-tools/tool-bar/marquee-mouse-tool';
 import { IvyChangeBoundsTool } from './change-bounds-tool';
 import { IvySvgExporter } from './export/ivy-svg-exporter';
+import { IvyDrawHelpersLineFeedbackCommand } from './helper-line-feedback';
+import { IvyHelperLineManager } from './ivy-helper-line-manager';
+import { IvyHiddenBoundsUpdater } from './ivy-hidden-bounds-updater';
 import { IvyNodeCreationTool } from './node-creation-tool';
 
 export const ivyChangeBoundsToolModule = new FeatureModule(
@@ -64,3 +72,20 @@ export const ivyMarqueeSelectionToolModule = new FeatureModule(bind => {
   // Ivy extensions
   bindAsService(bind, TYPES.ITool, IvyMarqueeMouseTool);
 });
+
+export const ivyHelperLineExtensionModule = new FeatureModule(
+  (bind, _unbind, _isBound, rebind) => {
+    rebind(DrawHelperLinesFeedbackCommand).to(IvyDrawHelpersLineFeedbackCommand);
+    bind(IvyHelperLineManager).toSelf().inSingletonScope();
+    rebind(HelperLineManager).toService(IvyHelperLineManager);
+  },
+  { featureId: helperLineModule.featureId }
+);
+
+export const ivyBoundsExtensionModule = new FeatureModule(
+  (bind, _unbind, _isBound, rebind) => {
+    bind(IvyHiddenBoundsUpdater).toSelf().inSingletonScope();
+    rebind(GLSPHiddenBoundsUpdater).toService(IvyHiddenBoundsUpdater);
+  },
+  { featureId: boundsModule.featureId }
+);

--- a/packages/editor/src/tools/helper-line-feedback.ts
+++ b/packages/editor/src/tools/helper-line-feedback.ts
@@ -1,0 +1,10 @@
+import { DrawHelperLinesFeedbackCommand } from '@eclipse-glsp/client';
+import { injectable } from 'inversify';
+
+@injectable()
+export class IvyDrawHelpersLineFeedbackCommand extends DrawHelperLinesFeedbackCommand {
+  protected isMatch(leftCoordinate: number, rightCoordinate: number, epsilon: number): boolean {
+    // fix: <= instead of <
+    return Math.abs(leftCoordinate - rightCoordinate) <= epsilon;
+  }
+}

--- a/packages/editor/src/tools/ivy-helper-line-manager.ts
+++ b/packages/editor/src/tools/ivy-helper-line-manager.ts
@@ -1,0 +1,10 @@
+import { HelperLineManager, SetBoundsAction, SetBoundsFeedbackAction } from '@eclipse-glsp/client';
+import { injectable } from 'inversify';
+
+@injectable()
+export class IvyHelperLineManager extends HelperLineManager {
+  protected handleSetBoundsAction(action: SetBoundsAction | SetBoundsFeedbackAction): void {
+    this.feedback.dispose();
+    super.handleSetBoundsAction(action);
+  }
+}

--- a/packages/editor/src/tools/ivy-hidden-bounds-updater.ts
+++ b/packages/editor/src/tools/ivy-hidden-bounds-updater.ts
@@ -1,0 +1,46 @@
+import {
+  Action,
+  BoundsAware,
+  BoundsAwareModelElement,
+  BoundsData,
+  CSS_GHOST_ELEMENT,
+  GLSPHiddenBoundsUpdater,
+  GModelElement,
+  LocalRequestBoundsAction,
+  hasArgs
+} from '@eclipse-glsp/client';
+import { injectable } from 'inversify';
+
+@injectable()
+export class IvyHiddenBoundsUpdater extends GLSPHiddenBoundsUpdater {
+  postUpdate(cause?: Action | undefined): void {
+    if (LocalRequestBoundsAction.is(cause)) {
+      // ensure we only actually change the bounds of the elements we are interested in
+      Array.from(this.getElement2BoundsData().keys())
+        .filter(element => !this.isElementToUpdate(element))
+        .forEach(unnecessary => this.getElement2BoundsData().delete(unnecessary));
+    }
+    const elementsToUpdate = new Map(this.getElement2BoundsData());
+    try {
+      super.postUpdate(cause);
+    } finally {
+      Array.from(elementsToUpdate.keys()).forEach(element => this.cleanUpElement(element));
+      elementsToUpdate.clear();
+    }
+  }
+
+  protected isElementToUpdate(element: BoundsAwareModelElement): boolean {
+    // ghost element or local set bounds element
+    return !!element.cssClasses?.includes(CSS_GHOST_ELEMENT);
+  }
+
+  protected cleanUpElement(element: BoundsAwareModelElement): void {
+    if (hasArgs(element) && element.args.requestBounds === true) {
+      delete element.args.requestBounds;
+    }
+  }
+
+  protected getElement2BoundsData(): Map<GModelElement & BoundsAware, BoundsData> {
+    return this['element2boundsData'];
+  }
+}

--- a/packages/editor/src/tools/node-creation-tool.ts
+++ b/packages/editor/src/tools/node-creation-tool.ts
@@ -5,13 +5,21 @@ import {
   CSS_HIDDEN,
   CursorCSS,
   GModelElement,
+  GNode,
+  Locateable,
+  ModifyCSSFeedbackAction,
   MouseTrackingElementPositionListener,
+  MoveAction,
   NodeCreationTool,
   NodeCreationToolMouseListener,
   Point,
+  TriggerNodeCreationAction,
   cursorFeedbackAction,
   getAbsolutePosition,
-  getTemplateElementId
+  getTemplateElementId,
+  isBoundsAware,
+  isMoveable,
+  useSnap
 } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 import { addNegativeArea } from './negative-area/model';
@@ -23,10 +31,10 @@ export class IvyNodeCreationTool extends NodeCreationTool {
   protected ivyCreationToolMouseListener: NodeCreationToolMouseListener;
 
   override doEnable(): void {
-    let trackingListener: MouseTrackingElementPositionListener | undefined;
+    let trackingListener: IvyMouseTrackingElementPositionListener | undefined;
     const ghostElement = this.triggerAction.ghostElement;
     if (ghostElement) {
-      trackingListener = new MouseTrackingElementPositionListener(getTemplateElementId(ghostElement.template), this, 'middle');
+      trackingListener = new IvyMouseTrackingElementPositionListener(getTemplateElementId(ghostElement.template), this, 'middle');
       this.toDisposeOnDisable.push(
         this.registerFeedback(
           [AddTemplateElementsAction.create({ templates: [ghostElement.template], addClasses: [CSS_HIDDEN, CSS_GHOST_ELEMENT] })],
@@ -46,6 +54,14 @@ export class IvyNodeCreationTool extends NodeCreationTool {
 
 @injectable()
 export class IvyNodeCreationToolMouseListener extends NodeCreationToolMouseListener {
+  constructor(
+    triggerAction: TriggerNodeCreationAction,
+    tool: NodeCreationTool,
+    protected trackingListener?: IvyMouseTrackingElementPositionListener
+  ) {
+    super(triggerAction, tool, trackingListener);
+  }
+
   override mouseMove(target: GModelElement, event: MouseEvent): Action[] {
     const absolutePos = getAbsolutePosition(target, event);
     if (absolutePos.x < 0 || absolutePos.y < 0) {
@@ -57,9 +73,64 @@ export class IvyNodeCreationToolMouseListener extends NodeCreationToolMouseListe
   }
 
   protected getInsertPosition(target: GModelElement, event: MouseEvent): Point {
-    if (this.trackingListener) {
-      return getAbsolutePosition(target, event);
+    if (this.trackingListener?.insertPosition) {
+      return this.trackingListener.insertPosition;
     }
     return super.getInsertPosition(target, event);
+  }
+}
+
+export class IvyMouseTrackingElementPositionListener extends MouseTrackingElementPositionListener {
+  insertPosition?: Point;
+
+  mouseMove(target: GModelElement, event: MouseEvent): Action[] {
+    if (this._isMouseDown) {
+      this._isMouseDrag = true;
+    }
+    const element = target.root.index.getById(this.elementId);
+    if (!element || !isMoveable(element)) {
+      return [];
+    }
+    const mousePosition = getAbsolutePosition(target, event);
+    if (this.positionUpdater.isLastDragPositionUndefined()) {
+      this.positionUpdater.updateLastDragPosition(element.position);
+    }
+    const delta = this.positionUpdater.updatePosition(element, mousePosition, useSnap(event));
+    if (!delta) {
+      return [];
+    }
+    const gridPosition = this.getMousePositionOnGrid(mousePosition, event);
+    let targetPosition = this.getElementTargetPosition(gridPosition, element);
+    targetPosition = this.validateMove(this.currentPosition ?? targetPosition, targetPosition, element, false);
+    const moveGhostElement = MoveAction.create(
+      [
+        {
+          elementId: element.id,
+          fromPosition: this.currentPosition,
+          toPosition: targetPosition
+        }
+      ],
+      { animate: false, finished: false }
+    );
+    this.currentPosition = targetPosition;
+    this.insertPosition = gridPosition;
+    this.tool.registerFeedback([moveGhostElement], this);
+    return element.cssClasses?.includes(CSS_HIDDEN)
+      ? [ModifyCSSFeedbackAction.create({ elements: [element.id], remove: [CSS_HIDDEN] })]
+      : [];
+  }
+
+  protected getMousePositionOnGrid(location: Point, event: MouseEvent): Point {
+    // Create a 0-bounds proxy element for snapping
+    const elementProxy = new GNode();
+    elementProxy.size = { width: 0, height: 0 };
+    return this.tool.positionSnapper.snapPosition(location, elementProxy);
+  }
+
+  protected getElementTargetPosition(gridPosition: Point, element: GModelElement & Locateable): Point {
+    if (this.cursorPosition === 'middle' && isBoundsAware(element)) {
+      return Point.subtract(gridPosition, { x: element.bounds.width / 2, y: element.bounds.height / 2 });
+    }
+    return gridPosition;
   }
 }

--- a/packages/inscription/package.json
+++ b/packages/inscription/package.json
@@ -14,7 +14,7 @@
     "@axonivy/inscription-editor": "~11.3.0-next.936",
     "@axonivy/inscription-protocol": "~11.3.0-next.936",
     "@axonivy/process-editor": "11.9.0-next",
-    "@eclipse-glsp/client": "2.1.0",
+    "@eclipse-glsp/client": "~2.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -18,7 +18,7 @@
     "bpmn"
   ],
   "dependencies": {
-    "@eclipse-glsp/protocol": "2.1.0"
+    "@eclipse-glsp/protocol": "~2.1.0"
   },
   "devDependencies": {
     "rimraf": "^5.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -119,7 +119,17 @@
     file-saver "^2.0.5"
     lodash "4.17.21"
 
-"@eclipse-glsp/ide@2.1.0":
+"@eclipse-glsp/client@~2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.1.1.tgz#fddbf5e129abeb2d5981efa34886364696191214"
+  integrity sha512-rSGMzfaBl/GCxhKW5j40FTO6vyqf6NtzMSMu9uNTuS7c20bwnjTNywAT0l3vqBIfKSQ+uEc/SMSNm80PB7+Prg==
+  dependencies:
+    "@eclipse-glsp/sprotty" "2.1.1"
+    autocompleter "^9.1.0"
+    file-saver "^2.0.5"
+    lodash "4.17.21"
+
+"@eclipse-glsp/ide@~2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/ide/-/ide-2.1.0.tgz#f1bc0fb76ab70f95aaad45bd39d5bef61c6d3a8e"
   integrity sha512-2feg3u2jIbtKI6cO//vwAXRpsH5FeZFHKnL+7f6cKJw2yhEig9UCvwghR7ugwdmW9YWcMsVfw57rARHmmpjT7g==
@@ -135,12 +145,32 @@
     uuid "7.0.3"
     vscode-jsonrpc "^8.0.2"
 
+"@eclipse-glsp/protocol@2.1.1", "@eclipse-glsp/protocol@~2.1.0":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/protocol/-/protocol-2.1.1.tgz#127e05473020954b8d2d6e3e30a16541f048f5b2"
+  integrity sha512-t9vcnI174eB6UVfj6bpyFOnc3MV0EN8VawFgniV+dgon++6Rbg2tyxlFRFfAs/itkYBCQkmeF2WdPe9v3CnosQ==
+  dependencies:
+    sprotty-protocol "1.0.0"
+    uuid "7.0.3"
+    vscode-jsonrpc "^8.0.2"
+
 "@eclipse-glsp/sprotty@2.1.0":
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.1.0.tgz#4adf93dd501dc65426f7beac145ac007fcb37aa9"
   integrity sha512-STBH3Af9sTD102mfgr0kplMSkvkkWIOMGLjr7Hl+b5yx8niMrFmy6HGIBVpyw9mb5DW+6eKN+3QjyslTetL8TA==
   dependencies:
     "@eclipse-glsp/protocol" "2.1.0"
+    autocompleter "^9.1.0"
+    snabbdom "^3.5.1"
+    sprotty "1.0.0"
+    sprotty-protocol "1.0.0"
+
+"@eclipse-glsp/sprotty@2.1.1":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/sprotty/-/sprotty-2.1.1.tgz#4a92aba406f0999c4de445198140e4161194dcb0"
+  integrity sha512-wiv+juFKzJEi+XnQ3DWbyaihMYhpqp+5bsjsSbwPd6csm/+yVpD90mdob43vm+ZSD43l79Fm4rseEXBQ0pvKdg==
+  dependencies:
+    "@eclipse-glsp/protocol" "2.1.1"
     autocompleter "^9.1.0"
     snabbdom "^3.5.1"
     sprotty "1.0.0"


### PR DESCRIPTION
- Ensure we always align the center of an element with the grid
-- Ensure we only use full integer positions
-- Be more restrictive with helper line matching (no delta allowed)
-- Ensure we use the correct position on insert
-- Ensure we properly calculate target vs insert position for ghost

- Fix ghost element in Firefox
-- 'display:hidden' is ignored in bounding box calculation -> restore
-- Adapt hidden bounds updater to only consider certain elements

- Adapt GLSP versions to get minor fixes