### PR TITLE
Progress notification should hide after end

### DIFF
--- a/packages/editor/src/di.config.ts
+++ b/packages/editor/src/di.config.ts
@@ -22,7 +22,8 @@ import {
   overrideViewerOptions,
   toolPaletteModule,
   viewportModule,
-  zorderModule
+  zorderModule,
+  statusModule
 } from '@eclipse-glsp/client';
 import { Container } from 'inversify';
 import ivyAnimateModule from './animate/di.config';
@@ -64,7 +65,7 @@ export default function createContainer(widgetId: string, ...containerConfigurat
   const container = initializeDiagramContainer(
     new Container(),
     // removals: not needed defaults
-    { remove: [hoverModule, navigationModule] },
+    { remove: [hoverModule, navigationModule, statusModule] },
 
     // GLSP additions
     baseViewModule,

--- a/packages/editor/src/notification/di.config.ts
+++ b/packages/editor/src/notification/di.config.ts
@@ -4,13 +4,15 @@ import {
   MessageAction,
   StartProgressAction,
   UpdateProgressAction,
-  configureActionHandler
+  configureActionHandler,
+  StatusAction
 } from '@eclipse-glsp/client';
 import { ToastNotificationService } from './notification-service';
 
 export const ivyNotificationModule = new FeatureModule((bind, unbind, isBound, rebind) => {
   const context = { bind, unbind, isBound, rebind };
   bind(ToastNotificationService).toSelf().inSingletonScope();
+  configureActionHandler(context, StatusAction.KIND, ToastNotificationService);
   configureActionHandler(context, MessageAction.KIND, ToastNotificationService);
   configureActionHandler(context, StartProgressAction.KIND, ToastNotificationService);
   configureActionHandler(context, UpdateProgressAction.KIND, ToastNotificationService);

--- a/packages/editor/src/notification/notification-service.ts
+++ b/packages/editor/src/notification/notification-service.ts
@@ -5,7 +5,8 @@ import {
   ICommand,
   MessageAction,
   StartProgressAction,
-  UpdateProgressAction
+  UpdateProgressAction,
+  SeverityLevel
 } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 import Toastify from 'toastify-js';
@@ -27,7 +28,7 @@ export class ToastNotificationService implements IActionHandler {
       return this.updateToast(this.progress(action), 'INFO');
     }
     if (EndProgressAction.is(action)) {
-      return this.updateToast(this.progress(action), 'INFO');
+      return this.updateToast(this.progress(action), 'NONE');
     }
   }
 
@@ -40,7 +41,7 @@ export class ToastNotificationService implements IActionHandler {
       message += message.length > 0 ? `${message}: ${action.message}` : action.message;
     }
     const percentage = EndProgressAction.is(action) ? undefined : action.percentage;
-    if (percentage) {
+    if (percentage && percentage > 0) {
       message += message.length > 0 ? `${message} (${percentage}%)` : `${percentage}%`;
     }
     if (EndProgressAction.is(action)) {
@@ -52,20 +53,20 @@ export class ToastNotificationService implements IActionHandler {
   protected message(action: MessageAction): void {
     this.messageToast?.hideToast();
     if (action.severity !== 'NONE') {
-      this.messageToast = this.createToast(action.message, action.severity, action.severity === 'ERROR' ? undefined : this.duration);
+      this.messageToast = this.createToast(action.message, action.severity);
       this.messageToast.showToast();
     }
   }
 
-  protected updateToast(text: string, severity: string, duration?: number): void {
+  protected updateToast(text: string, severity: SeverityLevel): void {
     this.messageToast?.hideToast();
     if (severity !== 'NONE') {
-      this.messageToast = this.createToast(text, severity, duration);
+      this.messageToast = this.createToast(text, severity);
       this.messageToast.showToast();
     }
   }
 
-  protected createToast(text: string, severity: string, duration?: number): any {
+  protected createToast(text: string, severity: SeverityLevel): any {
     return Toastify({
       text,
       close: true,


### PR DESCRIPTION
- Even if the progess is a cool improvement, the EndProgressAction should hide all notifications and no longer displays it 2s...
- There is still a status module which shows status messages in an own ui exension. Not sure if we really need this here, so I removed the module and ignore those messages