### PR TITLE
Remove unnecessary @injectable annotation and yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,10 +47,6 @@
     ]
   },
   "resolutions": {
-    "vscode-jsonrpc": "8.2.0",
-    "sprotty-protocol": "1.0.0",
-    "@eclipse-glsp/client": "2.1.1",
-    "@eclipse-glsp/protocol": "2.1.1",
-    "@eclipse-glsp/sprotty": "2.1.1"
+    "vscode-jsonrpc": "8.2.0"
   }
 }

--- a/packages/editor/src/tools/node-creation-tool.ts
+++ b/packages/editor/src/tools/node-creation-tool.ts
@@ -24,62 +24,6 @@ import {
 import { injectable } from 'inversify';
 import { addNegativeArea } from './negative-area/model';
 
-@injectable()
-export class IvyNodeCreationTool extends NodeCreationTool {
-  static ID = 'tool_create_node';
-
-  protected ivyCreationToolMouseListener: NodeCreationToolMouseListener;
-
-  override doEnable(): void {
-    let trackingListener: IvyMouseTrackingElementPositionListener | undefined;
-    const ghostElement = this.triggerAction.ghostElement;
-    if (ghostElement) {
-      trackingListener = new IvyMouseTrackingElementPositionListener(getTemplateElementId(ghostElement.template), this, 'middle');
-      this.toDisposeOnDisable.push(
-        this.registerFeedback(
-          [AddTemplateElementsAction.create({ templates: [ghostElement.template], addClasses: [CSS_HIDDEN, CSS_GHOST_ELEMENT] })],
-          ghostElement
-        ),
-        this.mouseTool.registerListener(trackingListener)
-      );
-    }
-    this.ivyCreationToolMouseListener = new IvyNodeCreationToolMouseListener(this.triggerAction, this, trackingListener);
-    this.toDisposeOnDisable.push(
-      this.mouseTool.registerListener(this.ivyCreationToolMouseListener),
-      this.registerFeedback([cursorFeedbackAction(CursorCSS.NODE_CREATION)], this, [cursorFeedbackAction()]),
-      addNegativeArea(this.editorContext.modelRoot)
-    );
-  }
-}
-
-@injectable()
-export class IvyNodeCreationToolMouseListener extends NodeCreationToolMouseListener {
-  constructor(
-    triggerAction: TriggerNodeCreationAction,
-    tool: NodeCreationTool,
-    protected trackingListener?: IvyMouseTrackingElementPositionListener
-  ) {
-    super(triggerAction, tool, trackingListener);
-  }
-
-  override mouseMove(target: GModelElement, event: MouseEvent): Action[] {
-    const absolutePos = getAbsolutePosition(target, event);
-    if (absolutePos.x < 0 || absolutePos.y < 0) {
-      this.tool.registerFeedback([cursorFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED)]);
-    } else {
-      this.tool.registerFeedback([cursorFeedbackAction(CursorCSS.NODE_CREATION)]);
-    }
-    return super.mouseMove(target, event);
-  }
-
-  protected getInsertPosition(target: GModelElement, event: MouseEvent): Point {
-    if (this.trackingListener?.insertPosition) {
-      return this.trackingListener.insertPosition;
-    }
-    return super.getInsertPosition(target, event);
-  }
-}
-
 export class IvyMouseTrackingElementPositionListener extends MouseTrackingElementPositionListener {
   insertPosition?: Point;
 
@@ -132,5 +76,60 @@ export class IvyMouseTrackingElementPositionListener extends MouseTrackingElemen
       return Point.subtract(gridPosition, { x: element.bounds.width / 2, y: element.bounds.height / 2 });
     }
     return gridPosition;
+  }
+}
+
+export class IvyNodeCreationToolMouseListener extends NodeCreationToolMouseListener {
+  constructor(
+    triggerAction: TriggerNodeCreationAction,
+    tool: NodeCreationTool,
+    protected trackingListener?: IvyMouseTrackingElementPositionListener
+  ) {
+    super(triggerAction, tool, trackingListener);
+  }
+
+  override mouseMove(target: GModelElement, event: MouseEvent): Action[] {
+    const absolutePos = getAbsolutePosition(target, event);
+    if (absolutePos.x < 0 || absolutePos.y < 0) {
+      this.tool.registerFeedback([cursorFeedbackAction(CursorCSS.OPERATION_NOT_ALLOWED)]);
+    } else {
+      this.tool.registerFeedback([cursorFeedbackAction(CursorCSS.NODE_CREATION)]);
+    }
+    return super.mouseMove(target, event);
+  }
+
+  protected getInsertPosition(target: GModelElement, event: MouseEvent): Point {
+    if (this.trackingListener?.insertPosition) {
+      return this.trackingListener.insertPosition;
+    }
+    return super.getInsertPosition(target, event);
+  }
+}
+
+@injectable()
+export class IvyNodeCreationTool extends NodeCreationTool {
+  static ID = 'tool_create_node';
+
+  protected ivyCreationToolMouseListener: NodeCreationToolMouseListener;
+
+  override doEnable(): void {
+    let trackingListener: IvyMouseTrackingElementPositionListener | undefined;
+    const ghostElement = this.triggerAction.ghostElement;
+    if (ghostElement) {
+      trackingListener = new IvyMouseTrackingElementPositionListener(getTemplateElementId(ghostElement.template), this, 'middle');
+      this.toDisposeOnDisable.push(
+        this.registerFeedback(
+          [AddTemplateElementsAction.create({ templates: [ghostElement.template], addClasses: [CSS_HIDDEN, CSS_GHOST_ELEMENT] })],
+          ghostElement
+        ),
+        this.mouseTool.registerListener(trackingListener)
+      );
+    }
+    this.ivyCreationToolMouseListener = new IvyNodeCreationToolMouseListener(this.triggerAction, this, trackingListener);
+    this.toDisposeOnDisable.push(
+      this.mouseTool.registerListener(this.ivyCreationToolMouseListener),
+      this.registerFeedback([cursorFeedbackAction(CursorCSS.NODE_CREATION)], this, [cursorFeedbackAction()]),
+      addNegativeArea(this.editorContext.modelRoot)
+    );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -109,7 +109,7 @@
     monaco-editor "0.44.0"
     vscode "npm:@codingame/monaco-vscode-api@1.83.5"
 
-"@eclipse-glsp/client@2.1.0", "@eclipse-glsp/client@2.1.1", "@eclipse-glsp/client@~2.1.0":
+"@eclipse-glsp/client@~2.1.0", "@eclipse-glsp/client@~2.1.1":
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@eclipse-glsp/client/-/client-2.1.1.tgz#fddbf5e129abeb2d5981efa34886364696191214"
   integrity sha512-rSGMzfaBl/GCxhKW5j40FTO6vyqf6NtzMSMu9uNTuS7c20bwnjTNywAT0l3vqBIfKSQ+uEc/SMSNm80PB7+Prg==
@@ -120,11 +120,11 @@
     lodash "4.17.21"
 
 "@eclipse-glsp/ide@~2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ide/-/ide-2.1.0.tgz#f1bc0fb76ab70f95aaad45bd39d5bef61c6d3a8e"
-  integrity sha512-2feg3u2jIbtKI6cO//vwAXRpsH5FeZFHKnL+7f6cKJw2yhEig9UCvwghR7ugwdmW9YWcMsVfw57rARHmmpjT7g==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@eclipse-glsp/ide/-/ide-2.1.1.tgz#58e0960858b7a8e5ceac804d357b6f728e9c2c1f"
+  integrity sha512-qFTDe4PAVV4QZdiZ38o2mcg6PQ8CIO89WnXrArMyyZtayXy/uoHs5SkEEOOZNpqw4FsfvNW1NopMVQfEqgRrIA==
   dependencies:
-    "@eclipse-glsp/client" "2.1.0"
+    "@eclipse-glsp/client" "~2.1.1"
 
 "@eclipse-glsp/protocol@2.1.1", "@eclipse-glsp/protocol@~2.1.0":
   version "2.1.1"


### PR DESCRIPTION
The emitted JavaScript code has proper meta-data but accesses the a class before it was declared/initialized since it is used in the constructor arguments. We can re-order the declarations or remove the injectable annotation to avoid the wrong access. We do both.

Remove unnecessary yarn resolutions and update yarn.lock