### PR TITLE
Fix intersection edge error

### DIFF
--- a/packages/editor/src/diagram/views.tsx
+++ b/packages/editor/src/diagram/views.tsx
@@ -9,7 +9,10 @@ import {
   GEdge,
   svg,
   toDegrees,
-  hasArgs
+  hasArgs,
+  IntersectingRoutedPoint,
+  SEdgeImpl,
+  IViewArgs
 } from '@eclipse-glsp/client';
 import { injectable } from 'inversify';
 import { VNode } from 'snabbdom';
@@ -106,6 +109,15 @@ export class WorkflowEdgeView extends PolylineEdgeViewWithGapsOnIntersections {
       path += ` L ${p.x},${p.y}`;
     }
     return path;
+  }
+
+  protected intersectionPath(edge: SEdgeImpl, segments: Point[], intersectingPoint: IntersectingRoutedPoint, args?: IViewArgs): string {
+    try {
+      return super.intersectionPath(edge, segments, intersectingPoint, args);
+    } catch (ex) {
+      // ingnore exception which can occur if one point of the segmet is NaN
+      return '';
+    }
   }
 }
 


### PR DESCRIPTION
Since the update to glsp 2.1.1 (or maybe it is the update of the sprotty inside), it can happen that the intersectionPath segmet contains a point with x and y is NaN which results in an error: 
```
Uncaught Error: Cannot determine direction of line (416,304) to (NaN,NaN)
    at get direction (geometry.ts:190:15)
    at WorkflowEdgeView.getIntersectionsSortedBySegmentDirection (views.tsx:185:29)
    at WorkflowEdgeView.intersectionPath (views.tsx:154:36)
    at WorkflowEdgeView.renderLine (views.tsx:136:30)
    at WorkflowEdgeView.renderLine (views.tsx:54:24)
    at WorkflowEdgeView.render (views.tsx:82:19)
    at _ModelRenderer.renderElement (viewer.tsx:65:28)
    at viewer.tsx:82:35
    at Array.map (<anonymous>)
    at _ModelRenderer.renderChildren (viewer.tsx:82:14)
```

![Screen Recording 2024-02-22 at 10 20 16](https://github.com/axonivy/process-editor-client/assets/42733123/4239173e-9ca0-482d-a5a0-1b7bfab418d4)


