### PR TITLE
Remove ivyThemeModule from default container

### DIFF
--- a/integration/eclipse/src/di.config.ts
+++ b/integration/eclipse/src/di.config.ts
@@ -5,7 +5,8 @@ import {
   ivyOpenDataClassModule,
   ivyOpenDecoratorBrowserModule,
   ivyOpenInscriptionModule,
-  ivyStartActionModule
+  ivyStartActionModule,
+  ivyThemeModule
 } from '@axonivy/process-editor';
 import { Container } from 'inversify';
 
@@ -27,6 +28,7 @@ export default function createContainer(widgetId: string, options: IvyDiagramOpt
   const container = createIvyDiagramContainer(
     widgetId,
     createDiagramOptionsModule(options),
+    ivyThemeModule,
     ivyEclipseCopyPasteModule,
     ivyEclipseDeleteModule,
     ivyOpenInscriptionModule,

--- a/integration/standalone/src/di.config.ts
+++ b/integration/standalone/src/di.config.ts
@@ -1,4 +1,4 @@
-import { createIvyDiagramContainer } from '@axonivy/process-editor';
+import { createIvyDiagramContainer, ivyThemeModule } from '@axonivy/process-editor';
 import { ivyInscriptionModule } from '@axonivy/process-editor-inscription';
 import { IDiagramOptions, createDiagramOptionsModule, standaloneSelectModule, undoRedoModule } from '@eclipse-glsp/client';
 import { Container } from 'inversify';
@@ -25,6 +25,7 @@ export default function createContainer(options: IvyDiagramOptions): Container {
     undoRedoModule,
     ivyStandaloneBreakpointModule,
     ivyStandaloneCopyPasteModule,
+    ivyThemeModule,
 
     // ivyNavigationModule is a replacement for navigationModule but it is already removed in the default IvyDiagramContainer
     ivyNavigationModule,

--- a/integration/viewer/src/di.config.ts
+++ b/integration/viewer/src/di.config.ts
@@ -1,4 +1,4 @@
-import { createIvyDiagramContainer } from '@axonivy/process-editor';
+import { createIvyDiagramContainer, ivyThemeModule } from '@axonivy/process-editor';
 import { ThemeMode } from '@axonivy/process-editor-protocol';
 import { IDiagramOptions, createDiagramOptionsModule } from '@eclipse-glsp/client';
 import { Container } from 'inversify';
@@ -14,6 +14,12 @@ export interface IvyDiagramOptions extends IDiagramOptions {
 
 export default function createContainer(options: IvyDiagramOptions): Container {
   // ivyNavigationModule is a replacement for navigationModule but it is already removed in the default IvyDiagramContainer
-  const container = createIvyDiagramContainer('sprotty', createDiagramOptionsModule(options), ivyNavigationModule, ivyStartupDiagramModule);
+  const container = createIvyDiagramContainer(
+    'sprotty',
+    createDiagramOptionsModule(options),
+    ivyThemeModule,
+    ivyNavigationModule,
+    ivyStartupDiagramModule
+  );
   return container;
 }

--- a/packages/editor/src/di.config.ts
+++ b/packages/editor/src/di.config.ts
@@ -96,7 +96,6 @@ export default function createContainer(widgetId: string, ...containerConfigurat
     ivyKeyListenerModule,
     ivyNotificationModule,
     ivyMarqueeSelectionToolModule,
-    ivyThemeModule,
 
     // Ivy extensions:
     ivyHelperLineExtensionModule,


### PR DESCRIPTION
Otherwise also the vscode integration gets the theme switch in the toolbar, which is wrong.
![Screen Recording 2024-02-26 at 09 39 17](https://github.com/axonivy/process-editor-client/assets/42733123/6765c85b-d87e-4901-ad27-a82c72c5977b)
