### PR TITLE
Fix lazy loaded monaco bundle

### DIFF
--- a/integration/eclipse/src/startup.ts
+++ b/integration/eclipse/src/startup.ts
@@ -1,14 +1,12 @@
 import { IVY_TYPES, ToolBar } from '@axonivy/process-editor';
 import { EnableInscriptionAction } from '@axonivy/process-editor-inscription';
-import { EnableViewportAction, ShowGridAction, SwitchThemeAction, UpdatePaletteItems } from '@axonivy/process-editor-protocol';
+import { EnableViewportAction, ShowGridAction, SwitchThemeAction, ThemeMode, UpdatePaletteItems } from '@axonivy/process-editor-protocol';
 import { EnableToolPaletteAction, GLSPActionDispatcher, IDiagramStartup, TYPES } from '@eclipse-glsp/client';
 import { ContainerModule, inject, injectable } from 'inversify';
 import { IvyDiagramOptions } from './di.config';
 
 import { MonacoUtil } from '@axonivy/inscription-core';
 import { MonacoEditorUtil } from '@axonivy/inscription-editor';
-import * as reactMonaco from 'monaco-editor/esm/vs/editor/editor.api';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import './index.css';
 
 @injectable()
@@ -34,8 +32,15 @@ export class EclipseDiagramStartup implements IDiagramStartup {
   }
 
   async postModelInitialization(): Promise<void> {
-    MonacoUtil.initStandalone(editorWorker).then(() => MonacoEditorUtil.initMonaco(reactMonaco, this.options.theme));
+    await this.initMonaco(this.options.theme);
     this.actionDispatcher.dispatch(EnableInscriptionAction.create({}));
+  }
+
+  async initMonaco(theme: ThemeMode): Promise<void> {
+    const monaco = await import('monaco-editor/esm/vs/editor/editor.api');
+    const editorWorker = await import('monaco-editor/esm/vs/editor/editor.worker?worker');
+    await MonacoUtil.initStandalone(editorWorker.default);
+    await MonacoEditorUtil.configureInstance(monaco, theme);
   }
 }
 

--- a/integration/eclipse/vite.config.js
+++ b/integration/eclipse/vite.config.js
@@ -12,8 +12,8 @@ export default defineConfig(() => {
       rollupOptions: {
         output: {
           manualChunks: id => {
-            if (id.includes('monaco-languageclient')) {
-              return 'monaco';
+            if (id.includes('monaco-languageclient' || id.includes('vscode'))) {
+              return 'monaco-chunk';
             }
           }
         }

--- a/integration/standalone/src/startup.ts
+++ b/integration/standalone/src/startup.ts
@@ -1,5 +1,5 @@
 import { EnableInscriptionAction } from '@axonivy/process-editor-inscription';
-import { EnableViewportAction, SwitchThemeAction, UpdatePaletteItems } from '@axonivy/process-editor-protocol';
+import { EnableViewportAction, SwitchThemeAction, ThemeMode, UpdatePaletteItems } from '@axonivy/process-editor-protocol';
 import {
   EnableToolPaletteAction,
   GLSPActionDispatcher,
@@ -13,8 +13,6 @@ import { IvyDiagramOptions } from './di.config';
 
 import { MonacoUtil } from '@axonivy/inscription-core';
 import { MonacoEditorUtil } from '@axonivy/inscription-editor';
-import * as reactMonaco from 'monaco-editor/esm/vs/editor/editor.api';
-import editorWorker from 'monaco-editor/esm/vs/editor/editor.worker?worker';
 import './index.css';
 
 @injectable()
@@ -36,7 +34,7 @@ export class StandaloneDiagramStartup implements IDiagramStartup {
   }
 
   async postModelInitialization(): Promise<void> {
-    MonacoUtil.initStandalone(editorWorker).then(() => MonacoEditorUtil.initMonaco(reactMonaco, this.options.theme));
+    await this.initMonaco(this.options.theme);
     this.actionDispatcher.dispatch(
       EnableInscriptionAction.create({
         connection: { server: this.options.inscriptionContext.server },
@@ -47,6 +45,13 @@ export class StandaloneDiagramStartup implements IDiagramStartup {
       const elementIds = this.options.select.split(NavigationTarget.ELEMENT_IDS_SEPARATOR);
       this.actionDispatcher.dispatch(SelectAction.create({ selectedElementsIDs: elementIds }));
     }
+  }
+
+  async initMonaco(theme: ThemeMode): Promise<void> {
+    const monaco = await import('monaco-editor/esm/vs/editor/editor.api');
+    const editorWorker = await import('monaco-editor/esm/vs/editor/editor.worker?worker');
+    await MonacoUtil.initStandalone(editorWorker.default);
+    await MonacoEditorUtil.configureInstance(monaco, theme);
   }
 }
 

--- a/integration/standalone/vite.config.js
+++ b/integration/standalone/vite.config.js
@@ -21,8 +21,8 @@ export default defineConfig(() => {
       rollupOptions: {
         output: {
           manualChunks: id => {
-            if (id.includes('monaco-languageclient')) {
-              return 'monaco';
+            if (id.includes('monaco-languageclient' || id.includes('vscode'))) {
+              return 'monaco-chunk';
             }
           }
         }

--- a/packages/inscription/package.json
+++ b/packages/inscription/package.json
@@ -10,9 +10,9 @@
     "url": "https://github.com/axonivy/glsp-editor-client"
   },
   "dependencies": {
-    "@axonivy/inscription-core": "~11.3.0-next.1009",
-    "@axonivy/inscription-editor": "~11.3.0-next.1009",
-    "@axonivy/inscription-protocol": "~11.3.0-next.1009",
+    "@axonivy/inscription-core": "~11.3.0-next.1014",
+    "@axonivy/inscription-editor": "~11.3.0-next.1014",
+    "@axonivy/inscription-protocol": "~11.3.0-next.1014",
     "@axonivy/process-editor": "11.3.0-next",
     "@eclipse-glsp/client": "~2.1.0",
     "react": "^18.2.0",

--- a/packages/inscription/src/inscription/inscription-ui.tsx
+++ b/packages/inscription/src/inscription/inscription-ui.tsx
@@ -101,7 +101,7 @@ export class InscriptionUi extends AbstractUIExtension implements IActionHandler
     if (this.action?.connection?.ivyScript) {
       await IvyScriptLanguage.startClient(this.action?.connection?.ivyScript);
     } else {
-      await IvyScriptLanguage.startWebSocketClient(webSocketAddress);
+      await IvyScriptLanguage.startWebSocketClient(webSocketAddress, Promise.resolve(true));
     }
     let client: InscriptionClient;
     if (this.action?.connection?.inscription) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,12 +7,12 @@
   resolved "https://registry.yarnpkg.com/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz#bd9154aec9983f77b3a034ecaa015c2e4201f6cf"
   integrity sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==
 
-"@axonivy/inscription-core@~11.3.0-next.1009":
-  version "11.3.0-next.1009"
-  resolved "https://npmjs-registry.ivyteam.ch/@axonivy/inscription-core/-/inscription-core-11.3.0-next.1009.tgz#e175a1cea271bbf70eb6a260bc1f41209b054f78"
-  integrity sha512-0DnLLKQWXMBJtHNfvB+NSNQRoa3TS0K22EAfvlVby2B4qDAbk0thtq6fWtUj4QTRaGvGuESDsp3WEdAPb8n0kQ==
+"@axonivy/inscription-core@~11.3.0-next.1014":
+  version "11.3.0-next.1014"
+  resolved "https://npmjs-registry.ivyteam.ch/@axonivy/inscription-core/-/inscription-core-11.3.0-next.1014.tgz#141b57903a0e5e1cee29af9393f49f2ff84252e3"
+  integrity sha512-Xenk68OoYQVJlF/ojLome+PTMVDj86ZowjsJa3QO+lHH3K+i7gWV+ncObNumAxmNCS/llaKCF9uBZeMVVHpo6g==
   dependencies:
-    "@axonivy/inscription-protocol" "11.3.0-next.1009+26e8690"
+    "@axonivy/inscription-protocol" "11.3.0-next.1014+a7da881"
     monaco-editor "^0.44.0"
     monaco-editor-workers "^0.44.0"
     monaco-languageclient "^6.6.1"
@@ -20,12 +20,12 @@
     vscode-languageserver-protocol "^3.17.5"
     vscode-ws-jsonrpc "^3.0.0"
 
-"@axonivy/inscription-editor@~11.3.0-next.1009":
-  version "11.3.0-next.1009"
-  resolved "https://npmjs-registry.ivyteam.ch/@axonivy/inscription-editor/-/inscription-editor-11.3.0-next.1009.tgz#ca9357a4603b1a42a5a7b3c6fe196eb3626105b8"
-  integrity sha512-WKToG1cM9bRguchuo+sxKj/WiMGL3DgXoFotv0MV4SuSgzfP7UgjwB/uCeHlu9o+3ONcqcOrkLp3xAaCZc1LFw==
+"@axonivy/inscription-editor@~11.3.0-next.1014":
+  version "11.3.0-next.1014"
+  resolved "https://npmjs-registry.ivyteam.ch/@axonivy/inscription-editor/-/inscription-editor-11.3.0-next.1014.tgz#863637a9b5f91c98b46fcdd2d0e22b45915f9716"
+  integrity sha512-lz9VrgFuzs+XySVjw/qvtgauVvKuhUBVN9e9gNLd9yvAvqnZnRCxmjB61wM6H+Upnp25AMywJGvhdSLXnwelgA==
   dependencies:
-    "@axonivy/inscription-protocol" "11.3.0-next.1009+26e8690"
+    "@axonivy/inscription-protocol" "11.3.0-next.1014+a7da881"
     "@monaco-editor/react" "^4.6.0"
     "@radix-ui/react-accordion" "^1.1.2"
     "@radix-ui/react-checkbox" "^1.0.4"
@@ -46,10 +46,10 @@
     react-aria "^3.31.0"
     react-error-boundary "^4.0.12"
 
-"@axonivy/inscription-protocol@11.3.0-next.1009+26e8690", "@axonivy/inscription-protocol@~11.3.0-next.1009":
-  version "11.3.0-next.1009"
-  resolved "https://npmjs-registry.ivyteam.ch/@axonivy/inscription-protocol/-/inscription-protocol-11.3.0-next.1009.tgz#c143c1aa698217c4697260ee21edb0bdf8a14922"
-  integrity sha512-atuIjpmfLDIf6bZxuvtsjm2AxGaJnXsp0Evh57RxlgoA5U+5nA+z8QZe5yKeMcAPLO3IZO6Trg10OlB1RiGJsw==
+"@axonivy/inscription-protocol@11.3.0-next.1014+a7da881", "@axonivy/inscription-protocol@~11.3.0-next.1014":
+  version "11.3.0-next.1014"
+  resolved "https://npmjs-registry.ivyteam.ch/@axonivy/inscription-protocol/-/inscription-protocol-11.3.0-next.1014.tgz#8bbc1bd4d6392a6a78ac68793f21974b8f4e1fd5"
+  integrity sha512-UqC1iVG1X5u3CIL12JWigE10JQTm7OBgmzMAjeLJgNLfzi24kYc8PxscN4tf8PvuD3UoPUwJ24njnP3fqlLDiw==
 
 "@axonivy/ui-icons@~11.3.0-next.67":
   version "11.3.0-next.67"


### PR DESCRIPTION
Currently, our build pipeline is broken because of the automatic update to the latest inscription view after the lazy moanco PR is merged: https://github.com/axonivy/inscription-client/pull/510

This should fix it.

Hi @martin-fleck-at 
I quickly fixed the process client build, so it can handle the API changes from the inscription view. Do you already work on this? Or how is you current state here?