### PR TITLE
Respect inscription view for shift quick action bar

### DIFF
--- a/packages/editor/src/ui-tools/quick-action/quick-action-ui.ts
+++ b/packages/editor/src/ui-tools/quick-action/quick-action-ui.ts
@@ -198,13 +198,14 @@ export class QuickActionUI extends IvyUIExtension implements IActionHandler, ISe
   private shiftBar(bar: HTMLElement, distanceToWindow = 16): void {
     const bounds = bar.getBoundingClientRect();
     let shift = bounds.width / 2;
+    const minShift = bounds.x + bounds.width + distanceToWindow - shift;
+    const diagramDiv = this.getParentContainer();
+    if (minShift > diagramDiv.offsetWidth) {
+      shift += minShift - diagramDiv.offsetWidth;
+    }
     const maxShift = bounds.x - distanceToWindow;
     if (shift > maxShift) {
       shift = maxShift;
-    }
-    const minShift = bounds.x + bounds.width + distanceToWindow - shift;
-    if (minShift > window.innerWidth) {
-      shift += minShift - window.innerWidth;
     }
     bar.style.marginLeft = `${-shift}px`;
   }


### PR DESCRIPTION
Instead of:
![image](https://github.com/axonivy/process-editor-client/assets/42733123/6ba80e33-398b-423e-af98-e9070e8b14c6)
shift to left if enough space:
![image](https://github.com/axonivy/process-editor-client/assets/42733123/2471f884-8357-4892-8e60-a148db40aca6)
