### PR TITLE
Avoid clicking overflowing suggestions on diagram changing selection

### DIFF
--- a/packages/editor/src/di.config.ts
+++ b/packages/editor/src/di.config.ts
@@ -32,7 +32,7 @@ import ivyKeyListenerModule from './key-listener/di.config';
 import ivyLaneModule from './lanes/di.config';
 import { ivyNotificationModule } from './notification/di.config';
 import { IvyViewerOptions, defaultIvyViewerOptions } from './options';
-import { ivyChangeBoundsToolModule, ivyExportModule } from './tools/di.config';
+import { ivyChangeBoundsToolModule, ivyExportModule, ivySelectModule } from './tools/di.config';
 import { IVY_TYPES } from './types';
 import ivyQuickActionModule from './ui-tools/quick-action/di.config';
 import ivyToolBarModule from './ui-tools/tool-bar/di.config';
@@ -68,6 +68,7 @@ export default function createContainer(widgetId: string, ...containerConfigurat
     { replace: ivyLabelEditUiModule },
     { replace: ivyChangeBoundsToolModule },
     { replace: ivyExportModule },
+    { replace: ivySelectModule },
 
     // Ivy additions
     ivyDiagramModule,

--- a/packages/editor/src/tools/di.config.ts
+++ b/packages/editor/src/tools/di.config.ts
@@ -6,13 +6,17 @@ import {
   FeatureModule,
   GResizeHandle,
   HideChangeBoundsToolResizeFeedbackCommand,
+  SelectAllCommand,
+  SelectCommand,
+  SelectFeedbackCommand,
   ShowChangeBoundsToolResizeFeedbackCommand,
   TYPES,
   bindAsService,
   changeBoundsToolModule,
   configureCommand,
   configureView,
-  exportModule
+  exportModule,
+  selectModule
 } from '@eclipse-glsp/client';
 
 import { IvyResizeHandleView } from '../diagram/views';
@@ -20,6 +24,7 @@ import { IvySvgExporter } from './export/ivy-svg-exporter';
 import './helper-line.css';
 import { IvyChangeBoundsManager } from './ivy-change-bounds-manager';
 import { ShowNegativeAreaFeedbackCommand } from './negative-area/model';
+import { IvySelectMouseListener } from './select-mouse-listener';
 
 export const ivyChangeBoundsToolModule = new FeatureModule(
   (bind, unbind, isBound, rebind) => {
@@ -50,4 +55,18 @@ export const ivyExportModule = new FeatureModule(
     bindAsService(context, TYPES.SvgExporter, IvySvgExporter);
   },
   { featureId: exportModule.featureId }
+);
+
+export const ivySelectModule = new FeatureModule(
+  (bind, _unbind, isBound) => {
+    const context = { bind, isBound };
+    // GLSP defaults
+    configureCommand(context, SelectCommand);
+    configureCommand(context, SelectAllCommand);
+    configureCommand(context, SelectFeedbackCommand);
+
+    // GLSP replacements
+    bindAsService(context, TYPES.MouseListener, IvySelectMouseListener);
+  },
+  { featureId: selectModule.featureId }
 );

--- a/packages/editor/src/tools/select-mouse-listener.ts
+++ b/packages/editor/src/tools/select-mouse-listener.ts
@@ -1,0 +1,16 @@
+import { GLSPMouseTool, GModelElement, RankedSelectMouseListener } from '@eclipse-glsp/client';
+import { injectable } from 'inversify';
+import { Action } from 'sprotty-protocol/lib/actions';
+
+export class IvyMouseTool extends GLSPMouseTool {}
+
+@injectable()
+export class IvySelectMouseListener extends RankedSelectMouseListener {
+  mouseUp(target: GModelElement, event: MouseEvent): (Action | Promise<Action>)[] {
+    if (!this.isMouseDown) {
+      // only handle mouse up if mouse down was also within the diagram
+      return [];
+    }
+    return super.mouseUp(target, event);
+  }
+}


### PR DESCRIPTION
The 'mousedown' event is happening on the suggestion overlay but the 'mouseup' event is happening on the diagram since the mousedown event already hides the suggestion widget. We therefore only adapt the selection if we also record a mousedown event.