### PR TITLE
XIVY-15151 Hide markers attached to the process graph

### DIFF
--- a/editor/css/diagram.css
+++ b/editor/css/diagram.css
@@ -302,3 +302,8 @@ g[class^='end'] .sprotty-node {
 svg {
   border: none;
 }
+
+/* Hide issue markers if the are on the graph */
+.sprotty-graph > g > g.sprotty-issue {
+  display: none;
+}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/28b2339a-3214-472b-af53-0138936fbf79)

After:
![image](https://github.com/user-attachments/assets/f8759890-0ba3-46d3-9ff8-6f8655a39c05)
