### PR TITLE
XIVY-15533 Add Condition Builder to Alternative Gateway

### DIFF
--- a/integration/inscription/package.json
+++ b/integration/inscription/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@axonivy/process-editor-inscription-core": "~12.0.1-next",
     "@axonivy/process-editor-inscription-view": "~12.0.1-next",
-    "@axonivy/ui-icons": "~12.0.1-next.384",
+    "@axonivy/ui-icons": "~12.0.1-next.386",
     "path-browserify": "^1.0.1"
   },
   "devDependencies": {

--- a/integration/standalone/package.json
+++ b/integration/standalone/package.json
@@ -13,7 +13,7 @@
     "@axonivy/process-editor": "~12.0.1-next",
     "@axonivy/process-editor-inscription": "~12.0.1-next",
     "@axonivy/process-editor-inscription-view": "~12.0.1-next",
-    "@axonivy/ui-components": "~12.0.1-next.384",
+    "@axonivy/ui-components": "~12.0.1-next.386",
     "@eclipse-glsp/client": "2.3.0-next.390"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -61,7 +61,7 @@
       "dependencies": {
         "@axonivy/process-editor-inscription-core": "~12.0.1-next",
         "@axonivy/process-editor-inscription-view": "~12.0.1-next",
-        "@axonivy/ui-icons": "~12.0.1-next.384",
+        "@axonivy/ui-icons": "~12.0.1-next.386",
         "path-browserify": "^1.0.1"
       },
       "devDependencies": {
@@ -82,7 +82,7 @@
         "@axonivy/process-editor": "~12.0.1-next",
         "@axonivy/process-editor-inscription": "~12.0.1-next",
         "@axonivy/process-editor-inscription-view": "~12.0.1-next",
-        "@axonivy/ui-components": "~12.0.1-next.384",
+        "@axonivy/ui-components": "~12.0.1-next.386",
         "@eclipse-glsp/client": "2.3.0-next.390"
       },
       "devDependencies": {
@@ -137,10 +137,9 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "12.0.1-next.384",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.1-next.384.tgz",
-      "integrity": "sha512-PFM4Lnnm4YYn6mCF4mjwUS0oyarTM2FgJrOQ925jhBee1Z2LHJksME9q6Pv8YlYYupD5dbV2LGh0goMlj2Zxqw==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "12.0.1-next.386",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-12.0.1-next.386.tgz",
+      "integrity": "sha512-rm3vyi0iZbK7eCekv8TKbvWenb9/aSUU4jxVAoidC9f55BcWIjaWJvGVqItZD3CvEWegGOlbTxYMgOi8/KZX1w==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
@@ -178,10 +177,9 @@
       "link": true
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "12.0.1-next.384",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.1-next.384.tgz",
-      "integrity": "sha512-t7G4vXQtK73XvyBhb53rAloQnKy34cN2IGgvQ/ucvEjicc5RipLpV+cO4oC7zqZaBYrRTIC9rTRr1Nk87EMV8Q==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "12.0.1-next.386",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-12.0.1-next.386.tgz",
+      "integrity": "sha512-gd/YTtvJnTY2j3R7fhqtb+MvAGHV/IQ/wxZuB6c6eoClKaM6YiUEJNMgH/QjSx8Qn12zATo2wYxCNHKhT9xs7g==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.1",
         "@radix-ui/react-checkbox": "1.1.2",
@@ -210,10 +208,9 @@
       }
     },
     "node_modules/@axonivy/ui-icons": {
-      "version": "12.0.1-next.384",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.1-next.384.tgz",
-      "integrity": "sha512-DnWRFCI5vdkUobqtt0ZltB/b7dzR/a5TSJDgHFtR5MJf5Et7e0pVbRHio4+QnAIPX91mD7vuoY9lIgYKiWMRmQ==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
+      "version": "12.0.1-next.386",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-12.0.1-next.386.tgz",
+      "integrity": "sha512-IWGzCKgkoF/u0ONo5X6Cl6bCn0CUmwnA4hHuS4Ev5P6abLkN0Wn/dLz/qYYhUx7isYOZu1fg5C4clMwX4evUBA=="
     },
     "node_modules/@axonivy/viewer-integration": {
       "resolved": "integration/viewer",
@@ -16780,7 +16777,7 @@
       "version": "12.0.1-next",
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
-        "@axonivy/jsonrpc": "~12.0.1-next.384",
+        "@axonivy/jsonrpc": "~12.0.1-next.386",
         "@axonivy/process-editor-inscription-protocol": "~12.0.1-next",
         "monaco-editor": "^0.44.0",
         "monaco-editor-workers": "^0.44.0",
@@ -16803,8 +16800,8 @@
       "dependencies": {
         "@axonivy/process-editor-inscription-core": "~12.0.1-next",
         "@axonivy/process-editor-inscription-protocol": "~12.0.1-next",
-        "@axonivy/ui-components": "~12.0.1-next.384",
-        "@axonivy/ui-icons": "~12.0.1-next.384",
+        "@axonivy/ui-components": "~12.0.1-next.386",
+        "@axonivy/ui-icons": "~12.0.1-next.386",
         "@monaco-editor/react": "^4.6.0",
         "@radix-ui/react-dialog": "1.1.2",
         "@radix-ui/react-radio-group": "1.2.1",

--- a/packages/inscription-core/package.json
+++ b/packages/inscription-core/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "dependencies": {
-    "@axonivy/jsonrpc": "~12.0.1-next.384",
+    "@axonivy/jsonrpc": "~12.0.1-next.386",
     "@axonivy/process-editor-inscription-protocol": "~12.0.1-next",
     "monaco-editor": "^0.44.0",
     "monaco-editor-workers": "^0.44.0",

--- a/packages/inscription-view/package.json
+++ b/packages/inscription-view/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@axonivy/process-editor-inscription-core": "~12.0.1-next",
     "@axonivy/process-editor-inscription-protocol": "~12.0.1-next",
-    "@axonivy/ui-components": "~12.0.1-next.384",
-    "@axonivy/ui-icons": "~12.0.1-next.384",
+    "@axonivy/ui-components": "~12.0.1-next.386",
+    "@axonivy/ui-icons": "~12.0.1-next.386",
     "@monaco-editor/react": "^4.6.0",
     "@radix-ui/react-dialog": "1.1.2",
     "@radix-ui/react-radio-group": "1.2.1",

--- a/packages/inscription-view/src/components/browser/Browser.tsx
+++ b/packages/inscription-view/src/components/browser/Browser.tsx
@@ -9,6 +9,7 @@ import { useTypeBrowser } from './type/TypeBrowser';
 import { useTableColBrowser } from './tableCol/TableColBrowser';
 import BrowserBody from './BrowserBody';
 import { useRoleBrowser, type RoleOptions } from './role/RoleBrowser';
+import { useConditionBuilder } from './conditionBuilder/useConditionBuilder';
 import { Button } from '@axonivy/ui-components';
 
 export type BrowserValue = { cursorValue: string; firstLineValue?: string };
@@ -49,8 +50,9 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, role
   );
   const tableColBrowser = useTableColBrowser(onRowDoubleClick);
   const roleBrowser = useRoleBrowser(onRowDoubleClick, roleOptions);
+  const conditionBuilder = useConditionBuilder();
 
-  const allBrowsers = [attrBrowser, cmsBrowser, funcBrowser, typeBrowser, tableColBrowser, roleBrowser];
+  const allBrowsers = [attrBrowser, cmsBrowser, funcBrowser, typeBrowser, tableColBrowser, roleBrowser, conditionBuilder];
 
   const tabs = allBrowsers.filter(browser => types.includes(browser.id));
 

--- a/packages/inscription-view/src/components/browser/BrowserBody.tsx
+++ b/packages/inscription-view/src/components/browser/BrowserBody.tsx
@@ -18,7 +18,12 @@ const BrowserBody = ({ open, tabs, activeTab, onTabsChange, onApply, disableAppl
 
   return (
     <DialogPortal container={editorRef.current}>
-      <DialogContent className={`browser-dialog ${!open ? 'browser-content-exit' : ''}`}>
+      <DialogContent
+        className={`browser-dialog ${!open ? 'browser-content-exit' : ''}`}
+        onInteractOutside={e => {
+          e.preventDefault();
+        }}
+      >
         <div className='browser-content'>
           <TabRoot tabs={tabs} value={activeTab} onChange={onTabsChange}>
             <DialogTitle className='browser-title'>

--- a/packages/inscription-view/src/components/browser/conditionBuilder/conditionBuilderData.test.ts
+++ b/packages/inscription-view/src/components/browser/conditionBuilder/conditionBuilderData.test.ts
@@ -1,0 +1,123 @@
+import { describe, test, expect } from 'vitest';
+import { generateConditionString } from './conditionBuilderData';
+import type { ConditionGroupData } from '@axonivy/ui-components';
+
+describe('generateConditionString', () => {
+  test('returns "true" for always-true mode', () => {
+    const result = generateConditionString('always-true', []);
+    expect(result).toBe('true');
+  });
+
+  test('returns "false" for always-false mode', () => {
+    const result = generateConditionString('always-false', []);
+    expect(result).toBe('false');
+  });
+
+  test('handles a basic condition with a single group', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [{ argument1: 'age', operator: 'greater than', argument2: '18', logicalOperator: 'and' }],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('basic-condition', conditionGroups);
+    expect(result).toBe('"age" > 18');
+  });
+
+  test('wraps arguments in quotes if needed', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [
+          { argument1: 'age', operator: 'greater than', argument2: '18', logicalOperator: 'and' },
+          { argument1: 'in.user', operator: 'equal to', argument2: 'admin', logicalOperator: 'and' }
+        ],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('nested-condition', conditionGroups);
+    expect(result).toBe('"age" > 18 && in.user == "admin"');
+  });
+
+  test('ignores additional groups in basic-condition mode', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [{ argument1: 'age', operator: 'greater than', argument2: '18', logicalOperator: 'and' }],
+        logicalOperator: 'and'
+      },
+      {
+        conditions: [{ argument1: 'status', operator: 'equal to', argument2: 'active', logicalOperator: 'or' }],
+        logicalOperator: 'or'
+      }
+    ];
+    const result = generateConditionString('basic-condition', conditionGroups);
+    expect(result).toBe('"age" > 18');
+  });
+
+  test('handles nested-condition mode with multiple groups', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [
+          { argument1: 'age', operator: 'greater than', argument2: '18', logicalOperator: 'and' },
+          { argument1: 'status', operator: 'equal to', argument2: 'active', logicalOperator: 'or' }
+        ],
+        logicalOperator: 'or'
+      },
+      {
+        conditions: [{ argument1: 'score', operator: 'less than', argument2: '50', logicalOperator: 'and' }],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('nested-condition', conditionGroups);
+    expect(result).toBe('("age" > 18 && "status" == "active") || ("score" < 50)');
+  });
+
+  test('handles is true operator', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [{ argument1: 'isAdmin', operator: 'is true', argument2: '', logicalOperator: 'and' }],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('basic-condition', conditionGroups);
+    expect(result).toBe('"isAdmin"');
+  });
+
+  test('handles is false operator', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [{ argument1: 'in.isAdmin', operator: 'is false', argument2: '', logicalOperator: 'and' }],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('basic-condition', conditionGroups);
+    expect(result).toBe('!in.isAdmin');
+  });
+
+  test('handles is empty and is not empty operators', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [
+          { argument1: 'in.names', operator: 'is empty', argument2: '', logicalOperator: 'and' },
+          { argument1: 'in.names', operator: 'is not empty', argument2: '', logicalOperator: 'and' }
+        ],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('basic-condition', conditionGroups);
+    expect(result).toBe('in.names.isEmpty() && !in.names.isEmpty()');
+  });
+
+  test('handles multiple conditions with logical operators', () => {
+    const conditionGroups: ConditionGroupData[] = [
+      {
+        conditions: [
+          { argument1: 'age', operator: 'greater than', argument2: '18', logicalOperator: 'and' },
+          { argument1: 'status', operator: 'equal to', argument2: 'active', logicalOperator: 'or' }
+        ],
+        logicalOperator: 'and'
+      }
+    ];
+    const result = generateConditionString('nested-condition', conditionGroups);
+    expect(result).toBe('"age" > 18 && "status" == "active"');
+  });
+});

--- a/packages/inscription-view/src/components/browser/conditionBuilder/conditionBuilderData.ts
+++ b/packages/inscription-view/src/components/browser/conditionBuilder/conditionBuilderData.ts
@@ -1,0 +1,70 @@
+import type { ConditionData, ConditionGroupData, ConditionMode, LogicOperator, LogicOperators, Operators } from '@axonivy/ui-components';
+
+export const typeOptions: Operators = {
+  'equal to': '==',
+  'not equal to': '!=',
+  'is true': 'isTrue',
+  'is false': 'isFalse',
+  'is empty': 'isEmpty',
+  'is not empty': 'isNotEmpty',
+  'less than': '<',
+  'greater than': '>',
+  'less or equal to': '<=',
+  'greater or equal to': '>='
+};
+
+export const logicalOperatorOptions: LogicOperators = {
+  and: '&&',
+  or: '||'
+};
+
+export const generateConditionString = (conditionMode: ConditionMode, conditionGroups: ConditionGroupData[]) => {
+  if (conditionMode === 'always-true') {
+    return 'true';
+  }
+  if (conditionMode === 'always-false') {
+    return 'false';
+  }
+  const wrapInQuotesIfNeeded = (arg: string) => {
+    const isNumeric = /^\d+$/.test(arg);
+    return arg.includes('.') || arg.startsWith('in') || arg.startsWith('out') || isNumeric ? arg : `"${arg}"`;
+  };
+
+  const groupStrings = conditionGroups.map((group, index) => {
+    if (conditionMode === 'basic-condition' && index > 0) return '';
+    const conditions = group.conditions
+      .map((con, conditionIndex) => {
+        const formattedArg1 = wrapInQuotesIfNeeded(con.argument1);
+        const formattedArg2 = wrapInQuotesIfNeeded(con.argument2);
+        const logicalOp = getLogicalOperator(conditionIndex, group.conditions.length, con.logicalOperator);
+        return formatCondition(con, formattedArg1, formattedArg2, logicalOp);
+      })
+      .join('');
+
+    const logicGroupOp = index < conditionGroups.length - 1 ? logicalOperatorOptions[group.logicalOperator].toLowerCase() : '';
+    return conditionGroups.length === 1 || conditionMode === 'basic-condition'
+      ? conditions
+      : `(${conditions})${logicGroupOp ? ` ${logicGroupOp} ` : ''}`;
+  });
+
+  return groupStrings.join('');
+};
+
+const getLogicalOperator = (index: number, totalConditions: number, logicalOperator: LogicOperator) => {
+  return index < totalConditions - 1 ? ` ${logicalOperatorOptions[logicalOperator].toLowerCase()} ` : '';
+};
+
+const formatCondition = (condition: ConditionData, formattedArg1: string, formattedArg2: string, logicalOp: string) => {
+  switch (condition.operator) {
+    case 'is true':
+      return `${formattedArg1}${logicalOp}`;
+    case 'is false':
+      return `!${formattedArg1}${logicalOp}`;
+    case 'is empty':
+      return `${formattedArg1}.isEmpty()${logicalOp}`;
+    case 'is not empty':
+      return `!${formattedArg1}.isEmpty()${logicalOp}`;
+    default:
+      return `${formattedArg1} ${typeOptions[condition.operator]} ${formattedArg2}${logicalOp}`;
+  }
+};

--- a/packages/inscription-view/src/components/browser/conditionBuilder/useConditionBuilder.tsx
+++ b/packages/inscription-view/src/components/browser/conditionBuilder/useConditionBuilder.tsx
@@ -1,0 +1,39 @@
+import { IvyIcons } from '@axonivy/ui-icons';
+import type { UseBrowserImplReturnValue } from '../useBrowser';
+import type { BrowserValue } from '../Browser';
+import { useState } from 'react';
+import { generateConditionString, logicalOperatorOptions, typeOptions } from './conditionBuilderData';
+import { ConditionBuilder, ConditionBuilderProvider } from '@axonivy/ui-components';
+import InputWithBrowser from '../../widgets/input/InputWithBrowser';
+
+export const CONDITION_BUILDER_ID = 'condition' as const;
+
+export const useConditionBuilder = (): UseBrowserImplReturnValue => {
+  const [condition, setCondition] = useState<BrowserValue>({ cursorValue: '' });
+
+  return {
+    id: CONDITION_BUILDER_ID,
+    name: 'Condition',
+    content: (
+      <>
+        <ConditionBuilderProvider
+          generateConditionString={generateConditionString}
+          logicalOperatorOptions={logicalOperatorOptions}
+          typeOptions={typeOptions}
+          argumentInput={(value, onChange) => (
+            <InputWithBrowser value={value} onChange={onChange} browsers={['attr']} style={{ flex: 1 }} />
+          )}
+        >
+          <ConditionBuilder onChange={e => setCondition({ cursorValue: e })} />
+        </ConditionBuilderProvider>
+        <pre
+          style={{ border: 'var(--basic-border)', maxHeight: '80px', padding: 'var(--input-padding)', borderRadius: 'var(--border-r2)' }}
+        >
+          {condition.cursorValue}
+        </pre>
+      </>
+    ),
+    accept: () => condition,
+    icon: IvyIcons.Process
+  };
+};

--- a/packages/inscription-view/src/components/browser/useBrowser.ts
+++ b/packages/inscription-view/src/components/browser/useBrowser.ts
@@ -7,6 +7,7 @@ import type { FUNCTION_BROWSER_ID } from './function/FunctionBrowser';
 import type { TYPE_BROWSER_ID } from './type/TypeBrowser';
 import type { TABLE_COL_BROWSER_ID } from './tableCol/TableColBrowser';
 import type { ROLE_BROWSER } from './role/RoleBrowser';
+import type { CONDITION_BUILDER_ID } from './conditionBuilder/useConditionBuilder';
 
 export type BrowserType =
   | typeof ATTRIBUTE_BROWSER_ID
@@ -14,7 +15,8 @@ export type BrowserType =
   | typeof FUNCTION_BROWSER_ID
   | typeof TYPE_BROWSER_ID
   | typeof TABLE_COL_BROWSER_ID
-  | typeof ROLE_BROWSER;
+  | typeof ROLE_BROWSER
+  | typeof CONDITION_BUILDER_ID;
 
 type BrowserValue = { cursorValue: string; firstLineValue?: string };
 

--- a/packages/inscription-view/src/components/parts/condition/ConditionTable.tsx
+++ b/packages/inscription-view/src/components/parts/condition/ConditionTable.tsx
@@ -45,7 +45,12 @@ const ConditionTable = ({ data, onChange }: { data: Condition[]; onChange: (chan
         header: () => <span>Expression</span>,
         cell: cell => (
           <ReorderHandleWrapper>
-            <ScriptCell cell={cell} type={IVY_SCRIPT_TYPES.BOOLEAN} browsers={['attr', 'func', 'type']} placeholder='Enter an Expression' />
+            <ScriptCell
+              cell={cell}
+              type={IVY_SCRIPT_TYPES.BOOLEAN}
+              browsers={['attr', 'func', 'type', 'condition']}
+              placeholder='Enter an Expression'
+            />
           </ReorderHandleWrapper>
         )
       }

--- a/packages/inscription-view/src/components/widgets/input/InputWithBrowser.tsx
+++ b/packages/inscription-view/src/components/widgets/input/InputWithBrowser.tsx
@@ -8,7 +8,7 @@ import { InputGroup } from '@axonivy/ui-components';
 
 type InputWithBrowserProps = InputProps & {
   browsers: BrowserType[];
-  typeFilter: CmsTypeFilter;
+  typeFilter?: CmsTypeFilter;
 };
 
 const InputWithBrowser = ({ onChange, browsers, typeFilter, ...props }: InputWithBrowserProps) => {
@@ -16,7 +16,7 @@ const InputWithBrowser = ({ onChange, browsers, typeFilter, ...props }: InputWit
   const path = usePath();
 
   return (
-    <InputGroup>
+    <InputGroup style={{ flex: '1' }}>
       <Input onChange={onChange} {...props} />
       <Browser
         {...browser}


### PR DESCRIPTION
I’ve integrated the Condition Builder into the alternative gateway in the inscription. For now, I’ve copied most of the code from the Form Editor and created a custom implementation, with adjustments to integrate the Builder as a browser and remove EL expressions at the output.

![conditionbuilder-inscription](https://github.com/user-attachments/assets/8c377a6c-d0d0-4647-898f-474c16168345)
