### PR TITLE
XIVY-15540 render HTML of javadoc

### DIFF
--- a/packages/inscription-view/src/components/browser/type/TypeBrowser.tsx
+++ b/packages/inscription-view/src/components/browser/type/TypeBrowser.tsx
@@ -268,7 +268,7 @@ const TypeBrowser = ({ value, onChange, onDoubleClick, initSearchFilter, locatio
       {showHelper && (
         <pre className='browser-helptext'>
           <b>{value}</b>
-          <code>{doc}</code>
+          <span dangerouslySetInnerHTML={{ __html: `${doc}` }}></span>
         </pre>
       )}
       <Checkbox label='Use Type as List' value={typeAsList} onChange={() => setTypeAsList(!typeAsList)} />

--- a/playwright/inscription-test-project/dataclasses/ch/ivyteam/test/Person.d.json
+++ b/playwright/inscription-test-project/dataclasses/ch/ivyteam/test/Person.d.json
@@ -2,7 +2,7 @@
   "$schema" : "https://json-schema.axonivy.com/data-class/12.0.0/data-class.json",
   "simpleName" : "Person",
   "namespace" : "ch.ivyteam.test",
-  "comment" : "A registered webshop user",
+  "comment" : "A registered webshop user \uD83D\uDD10",
   "isBusinessCaseData" : false,
   "fields" : [ {
     "name" : "name",

--- a/playwright/tests/screenshots/inscription/browsers.spec.ts
+++ b/playwright/tests/screenshots/inscription/browsers.spec.ts
@@ -36,6 +36,7 @@ test.describe('Browsers', () => {
     await browser.openTab('Type');
     await browser.search('Per');
     await browser.table.getByRole('row', { name: 'Person :' }).first().click();
+    await expect(browser.help).toContainText('registered webshop user');
     await screenshot(dialog, 'browser-type.png');
   });
 


### PR DESCRIPTION
brings stiflers mum back on stage 

![stifflers-mum-data](https://github.com/user-attachments/assets/14a60537-3fec-4202-9b24-c9afb6da68e4)


... no honestly; let's render javadoc HTMLs ... e.g apache commons StringUtils 
![html-docs](https://github.com/user-attachments/assets/dd265377-dfde-4ba2-9d16-1e0d68ffd947)
