### PR TITLE
XIVY-15533 Add improvements to condition builder from review

### DIFF
--- a/packages/inscription-view/src/components/browser/Browser.tsx
+++ b/packages/inscription-view/src/components/browser/Browser.tsx
@@ -52,7 +52,7 @@ const Browser = ({ open, onOpenChange, types, accept, location, cmsOptions, role
   const roleBrowser = useRoleBrowser(onRowDoubleClick, roleOptions);
   const conditionBuilder = useConditionBuilder();
 
-  const allBrowsers = [attrBrowser, cmsBrowser, funcBrowser, typeBrowser, tableColBrowser, roleBrowser, conditionBuilder];
+  const allBrowsers = [conditionBuilder, attrBrowser, cmsBrowser, funcBrowser, typeBrowser, tableColBrowser, roleBrowser];
 
   const tabs = allBrowsers.filter(browser => types.includes(browser.id));
 

--- a/packages/inscription-view/src/components/browser/conditionBuilder/useConditionBuilder.tsx
+++ b/packages/inscription-view/src/components/browser/conditionBuilder/useConditionBuilder.tsx
@@ -26,10 +26,9 @@ export const useConditionBuilder = (): UseBrowserImplReturnValue => {
         >
           <ConditionBuilder onChange={e => setCondition({ cursorValue: e })} />
         </ConditionBuilderProvider>
-        <pre
-          style={{ border: 'var(--basic-border)', maxHeight: '80px', padding: 'var(--input-padding)', borderRadius: 'var(--border-r2)' }}
-        >
-          {condition.cursorValue}
+        <pre className='browser-helptext'>
+          <b>Generated Condition</b>
+          <code>{condition.cursorValue}</code>
         </pre>
       </>
     ),

--- a/packages/inscription-view/src/components/parts/condition/ConditionTable.tsx
+++ b/packages/inscription-view/src/components/parts/condition/ConditionTable.tsx
@@ -48,7 +48,7 @@ const ConditionTable = ({ data, onChange }: { data: Condition[]; onChange: (chan
             <ScriptCell
               cell={cell}
               type={IVY_SCRIPT_TYPES.BOOLEAN}
-              browsers={['attr', 'func', 'type', 'condition']}
+              browsers={['condition', 'attr', 'func']}
               placeholder='Enter an Expression'
             />
           </ReorderHandleWrapper>

--- a/packages/inscription-view/src/components/parts/query/database/Condition.tsx
+++ b/packages/inscription-view/src/components/parts/query/database/Condition.tsx
@@ -21,7 +21,7 @@ export const Condition = () => {
           <MacroArea
             value={config.query.sql.condition}
             onChange={change => updateSql('condition', change)}
-            browsers={['tablecol', 'attr', 'condition']}
+            browsers={['tablecol', 'attr']}
             maximizeState={maximizeState}
           />
         </ValidationFieldset>

--- a/packages/inscription-view/src/components/widgets/code-editor/useCodeEditor.ts
+++ b/packages/inscription-view/src/components/widgets/code-editor/useCodeEditor.ts
@@ -42,11 +42,20 @@ export const useMonacoEditor = (options?: { modifyAction?: ModifyAction }) => {
         value.cursorValue.length > 0 && options?.modifyAction && type !== 'tablecol'
           ? options.modifyAction(value.cursorValue)
           : value.cursorValue;
-      editor.executeEdits('browser', [{ range: selection, text, forceMoveMarkers: true }]);
+      const editorModel = editor.getModel();
+      if (type === 'condition' && editorModel) {
+        editor.executeEdits('browser', [
+          {
+            range: editorModel.getFullModelRange(),
+            text,
+            forceMoveMarkers: true
+          }
+        ]);
+      } else {
+        editor.executeEdits('browser', [{ range: selection, text, forceMoveMarkers: true }]);
+      }
       if (type === 'func') {
         const updatedEditorContent = editor.getValue();
-        const editorModel = editor.getModel();
-
         if (editorModel && text.indexOf('(') !== -1) {
           const textIndex = updatedEditorContent.indexOf(text);
 


### PR DESCRIPTION
I made several improvements to the condition builder from Bruno:
- Removed condition builder from the database element, as conditions must be valid SQL, which browsers don’t yet know
- Moved Condition Builder to the front of the browsers
- Added a header to the info section
- Made condition builder to override the entire editor content when applied, instead of inserting at the cursor.