### PR TITLE
XIVY-13010 Fix regresion bug on direct move an element

### DIFF
--- a/packages/editor/src/tools/ivy-change-bounds-tool.ts
+++ b/packages/editor/src/tools/ivy-change-bounds-tool.ts
@@ -11,8 +11,8 @@ export class IvyChangeBoundsTool extends ChangeBoundsTool {
 
 export class IvyChangeBoundsListener extends ChangeBoundsListener {
   override mouseDown(target: GModelElement, event: MouseEvent) {
-    if (this.activeResizeElement) {
-      // We still have a resize element, so we don't need to reevaluate it.
+    if (this.activeResizeElement && this.activeResizeElement instanceof LaneNode) {
+      // We still have an active lane resize element (move), so we don't need to reevaluate it.
       // This may happens because the mouse left the window.
       return [];
     }


### PR DESCRIPTION
The fix about do not reevaluate the resize element (e.g. when the mouse leaves the window) broke the ability to direct move an element. If you didn't select an element first, but directly draged it to a new location, this update wasn't sent to the backend.
Now we add this lane fix only, the activeResizeElement is an instance of a LaneNode

Fixes:
![Screen Recording 2024-12-04 at 09 30 26](https://github.com/user-attachments/assets/663daae0-1c81-41f8-b805-e3a54c132afe)
