### PR TITLE
XIVY-15861 Set predefined width to avoid placeholder in monaco to ove…

### DIFF
--- a/packages/inscription-view/src/components/widgets/code-editor/CodeEditor.css
+++ b/packages/inscription-view/src/components/widgets/code-editor/CodeEditor.css
@@ -19,6 +19,9 @@
   position: absolute;
   display: none;
   white-space: nowrap;
+  text-overflow: ellipsis;
+  width: calc(100% - 60px);
+  overflow: hidden;
   top: 12px;
   left: 11px;
   font-size: 12px;

--- a/packages/inscription-view/src/components/widgets/table/cell/CodeEditorCell.css
+++ b/packages/inscription-view/src/components/widgets/table/cell/CodeEditorCell.css
@@ -39,4 +39,5 @@
 
 .ui-table-cell .script-input .maximize-code-button {
   margin-right: 30px;
+  background-color: var(--N25);
 }


### PR DESCRIPTION
I set the placeholder width to 68% and enabled text-overflow: ellipsis; (three dots at the end of the text) to prevent the text from overflowing behind the buttons. The 68% width seems like a good balance. I also set the maximize button’s background to ensure the text is hidden behind it if it’s too long.

![grafik](https://github.com/user-attachments/assets/43038ae9-cd8b-469f-a06d-ce375afa325a)
![grafik](https://github.com/user-attachments/assets/2c1ec933-78a1-4627-a729-f04f9e9a9e58)
![grafik](https://github.com/user-attachments/assets/e190e2a2-755c-49c5-a921-9df6f90844d8)

I know percentages can be tricky (due to screen sizes, etc.), but dynamically adjusting the placeholder width based on the Monaco editor’s width seems unnecessarily complex. What do you think?