### PR TITLE
XIVY-15861 Improve keyboard navigation in editable tables

### DIFF
--- a/integration/inscription/package.json
+++ b/integration/inscription/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@axonivy/process-editor-inscription-core": "~13.1.0-next",
     "@axonivy/process-editor-inscription-view": "~13.1.0-next",
-    "@axonivy/ui-icons": "~13.1.0-next.451",
+    "@axonivy/ui-icons": "~13.1.0-next.502",
     "path-browserify": "^1.0.1"
   },
   "devDependencies": {

--- a/integration/standalone/package.json
+++ b/integration/standalone/package.json
@@ -13,7 +13,7 @@
     "@axonivy/process-editor": "~13.1.0-next",
     "@axonivy/process-editor-inscription": "~13.1.0-next",
     "@axonivy/process-editor-inscription-view": "~13.1.0-next",
-    "@axonivy/ui-components": "~13.1.0-next.451",
+    "@axonivy/ui-components": "~13.1.0-next.502",
     "@eclipse-glsp/client": "2.3.0"
   },
   "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "parent",
       "version": "11.4.0-next",
       "devDependencies": {
-        "@axonivy/eslint-config": "~13.1.0-next.451",
+        "@axonivy/eslint-config": "~13.1.0-next.502",
         "@types/node": "^22.10.7",
         "lerna": "^8.1.9",
         "prettier": "^2.8.0",
@@ -53,7 +53,7 @@
       "dependencies": {
         "@axonivy/process-editor-inscription-core": "~13.1.0-next",
         "@axonivy/process-editor-inscription-view": "~13.1.0-next",
-        "@axonivy/ui-icons": "~13.1.0-next.451",
+        "@axonivy/ui-icons": "~13.1.0-next.502",
         "path-browserify": "^1.0.1"
       },
       "devDependencies": {
@@ -74,7 +74,7 @@
         "@axonivy/process-editor": "~13.1.0-next",
         "@axonivy/process-editor-inscription": "~13.1.0-next",
         "@axonivy/process-editor-inscription-view": "~13.1.0-next",
-        "@axonivy/ui-components": "~13.1.0-next.451",
+        "@axonivy/ui-components": "~13.1.0-next.502",
         "@eclipse-glsp/client": "2.3.0"
       },
       "devDependencies": {
@@ -157,11 +157,10 @@
       "link": true
     },
     "node_modules/@axonivy/eslint-config": {
-      "version": "13.1.0-next.451",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/eslint-config/-/eslint-config-13.1.0-next.451.tgz",
-      "integrity": "sha512-bzCSpqCRrtpoItysQuX0NWb1o8TrQOBWpvyP2KR6qYlkZ0nMlbT8wDwHvQJpAbL97CqThq8fJx9jQuPDsMr06A==",
+      "version": "13.1.0-next.502",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/eslint-config/-/eslint-config-13.1.0-next.502.tgz",
+      "integrity": "sha512-YTjpxrZC/cyUd2QotH0bRMO+2cd5jYKKY0wlUzsH/q/WfdebGWdS8RnOop8fHZse09H//ox2esR6B+Xsn2ALlQ==",
       "dev": true,
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
         "@eslint/js": "^9.17.0",
         "@tanstack/eslint-plugin-query": "^5.62.9",
@@ -182,10 +181,9 @@
       "link": true
     },
     "node_modules/@axonivy/jsonrpc": {
-      "version": "13.1.0-next.451",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-13.1.0-next.451.tgz",
-      "integrity": "sha512-uX63WKlg0fs1vf/j+LY1wznwam9YXQ0fSy0wGLC3gadOwhVrZspQzqCoRRe4oSOdC9WDxWMg9H7MNqkQKsVAiw==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "13.1.0-next.502",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/jsonrpc/-/jsonrpc-13.1.0-next.502.tgz",
+      "integrity": "sha512-oJ26fovrhy+SoFSPHtB3HXK9ckh0euin+TRqYLm5YZ3NoF/d30Nk1SN+YWR3WO99w2de9TK4DcKPsn5L1tdQ+Q==",
       "dependencies": {
         "vscode-jsonrpc": "^8.2.0"
       }
@@ -223,43 +221,102 @@
       "link": true
     },
     "node_modules/@axonivy/ui-components": {
-      "version": "13.1.0-next.451",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-13.1.0-next.451.tgz",
-      "integrity": "sha512-nli1/N+N04tcw6ciKzc8+Z0stEubsxgakbO4ebbDWmUmEQ/na2AWwdWk25hmgFSGfI/kHnJgu8MVVy8sM2J9OA==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
+      "version": "13.1.0-next.502",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-components/-/ui-components-13.1.0-next.502.tgz",
+      "integrity": "sha512-P4Hnql8miYUquR870pOSIpwQvZd3jSRgUoPhyiLeB/es76u9X+CXIcfEGp60YtlxAImgN4LiEN7LRWQMhe4YpA==",
       "dependencies": {
         "@radix-ui/react-accordion": "1.2.2",
         "@radix-ui/react-checkbox": "1.1.3",
         "@radix-ui/react-collapsible": "1.1.2",
-        "@radix-ui/react-dialog": "1.1.4",
-        "@radix-ui/react-dropdown-menu": "2.1.4",
+        "@radix-ui/react-dialog": "1.1.5",
+        "@radix-ui/react-dropdown-menu": "2.1.5",
         "@radix-ui/react-label": "2.1.1",
-        "@radix-ui/react-popover": "1.1.4",
+        "@radix-ui/react-popover": "1.1.5",
         "@radix-ui/react-radio-group": "1.2.2",
-        "@radix-ui/react-select": "2.1.4",
+        "@radix-ui/react-select": "2.1.5",
         "@radix-ui/react-separator": "1.1.1",
         "@radix-ui/react-switch": "1.1.2",
         "@radix-ui/react-tabs": "1.1.2",
         "@radix-ui/react-toggle-group": "1.1.1",
-        "@radix-ui/react-tooltip": "1.1.6",
+        "@radix-ui/react-tooltip": "1.1.7",
         "@react-aria/dnd": "3.8.1",
         "@tanstack/react-table": "8.20.6",
         "clsx": "2.1.1",
         "downshift": "9.0.8",
         "react-hotkeys-hook": "4.6.1",
         "react-resizable-panels": "2.1.7",
-        "sonner": "1.7.2"
+        "sonner": "1.7.4"
       },
       "peerDependencies": {
         "@axonivy/ui-icons": "~13.1.0-next",
         "react": "^18.2 || ^19.0"
       }
     },
+    "node_modules/@axonivy/ui-components/node_modules/@radix-ui/react-dialog": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.5.tgz",
+      "integrity": "sha512-LaO3e5h/NOEL4OfXjxD43k9Dx+vn+8n+PCFt6uhX/BADFflllyv3WJG6rgvvSVBxpTch938Qq/LGc2MMxipXPw==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-context": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
+        "@radix-ui/react-focus-guards": "1.1.1",
+        "@radix-ui/react-focus-scope": "1.1.1",
+        "@radix-ui/react-id": "1.1.0",
+        "@radix-ui/react-portal": "1.1.3",
+        "@radix-ui/react-presence": "1.1.2",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-slot": "1.1.1",
+        "@radix-ui/react-use-controllable-state": "1.1.0",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@axonivy/ui-components/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@axonivy/ui-icons": {
-      "version": "13.1.0-next.451",
-      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-13.1.0-next.451.tgz",
-      "integrity": "sha512-eXpIwRdMin86Z0C5iD6RCq+3b+Vu8/tLY1ey2WjinooGR9ox17cXTYWZW0fOdhJPYUwvSHqdkemEAGIKsVTkzg==",
-      "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)"
+      "version": "13.1.0-next.502",
+      "resolved": "https://npmjs-registry.ivyteam.ch/@axonivy/ui-icons/-/ui-icons-13.1.0-next.502.tgz",
+      "integrity": "sha512-UiajDs6p4vdCwJ7t2iVv24R9R8XC4jnlPHkMrPzLObq3F/ueSS9ZiEnA+KjM0/MfBHW8vDpGsDau+18D4wWjNg=="
     },
     "node_modules/@axonivy/viewer-integration": {
       "resolved": "integration/viewer",
@@ -1480,7 +1537,6 @@
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
       "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.9"
       }
@@ -1489,7 +1545,6 @@
       "version": "1.6.13",
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
       "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.6.0",
         "@floating-ui/utils": "^0.2.9"
@@ -1499,7 +1554,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
       "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.0.0"
       },
@@ -1511,8 +1565,7 @@
     "node_modules/@floating-ui/utils": {
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT"
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "node_modules/@formatjs/ecma402-abstract": {
       "version": "2.3.2",
@@ -2976,8 +3029,7 @@
     "node_modules/@radix-ui/number": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.0.tgz",
-      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ==",
-      "license": "MIT"
+      "integrity": "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="
     },
     "node_modules/@radix-ui/primitive": {
       "version": "1.1.1",
@@ -3020,7 +3072,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.1.tgz",
       "integrity": "sha512-NaVpZfmv8SKeZbn4ijN2V3jlHA9ngBG16VnIIm22nUR0Yk8KUALyBxT3KYEUnNuch9sTE8UTsS3whzBgKOL30w==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
       },
@@ -3234,16 +3285,15 @@
       }
     },
     "node_modules/@radix-ui/react-dropdown-menu": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.4.tgz",
-      "integrity": "sha512-iXU1Ab5ecM+yEepGAWK8ZhMyKX4ubFdCNtol4sT9D0OVErG9PNElfx3TQhjw7n7BC5nFVz68/5//clWy+8TXzA==",
-      "license": "MIT",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.5.tgz",
+      "integrity": "sha512-50ZmEFL1kOuLalPKHrLWvPFMons2fGx9TqQCWlPwDVpbAnaUJ1g4XNcKqFNMQymYU0kKWR4MDDi+9vUQBGFgcQ==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
-        "@radix-ui/react-menu": "2.1.4",
+        "@radix-ui/react-menu": "2.1.5",
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-use-controllable-state": "1.1.0"
       },
@@ -3344,17 +3394,16 @@
       }
     },
     "node_modules/@radix-ui/react-menu": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.4.tgz",
-      "integrity": "sha512-BnOgVoL6YYdHAG6DtXONaR29Eq4nvbi8rutrV/xlr3RQCMMb3yqP85Qiw/3NReozrSW+4dfLkK+rc1hb4wPU/A==",
-      "license": "MIT",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.5.tgz",
+      "integrity": "sha512-uH+3w5heoMJtqVCgYOtYVMECk1TOrkUn0OG0p5MqXC0W2ppcuVeESbou8PTHoqAjbdTEK19AGXBWcEtR5WpEQg==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-collection": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
         "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
@@ -3365,8 +3414,34 @@
         "@radix-ui/react-roving-focus": "1.1.1",
         "@radix-ui/react-slot": "1.1.1",
         "@radix-ui/react-use-callback-ref": "1.1.0",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.6.1"
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3384,15 +3459,14 @@
       }
     },
     "node_modules/@radix-ui/react-popover": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.4.tgz",
-      "integrity": "sha512-aUACAkXx8LaFymDma+HQVji7WhvEhpFJ7+qPz17Nf4lLZqtreGOFRiNQWQmhzp7kEWg9cOyyQJpdIMUMPc/CPw==",
-      "license": "MIT",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.5.tgz",
+      "integrity": "sha512-YXkTAftOIW2Bt3qKH8vYr6n9gCkVrvyvfiTObVjoHVTHnNj26rmvO87IKa3VgtgCjb8FAQ6qOjNViwl+9iIzlg==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
         "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
@@ -3402,8 +3476,34 @@
         "@radix-ui/react-primitive": "2.0.1",
         "@radix-ui/react-slot": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.1.0",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.6.1"
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3424,7 +3524,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.1.tgz",
       "integrity": "sha512-3kn5Me69L+jv82EKRuQCXdYyf1DqHwD2U/sxoNgBGCB7K9TRc3bQamQ+5EPM9EvyPdli0W41sROd+ZU1dTCztw==",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.0",
         "@radix-ui/react-arrow": "1.1.1",
@@ -3587,10 +3686,9 @@
       }
     },
     "node_modules/@radix-ui/react-select": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.4.tgz",
-      "integrity": "sha512-pOkb2u8KgO47j/h7AylCj7dJsm69BXcjkrvTqMptFqsE2i0p8lHkfgneXKjAgPzBMivnoMyt8o4KiV4wYzDdyQ==",
-      "license": "MIT",
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-select/-/react-select-2.1.5.tgz",
+      "integrity": "sha512-eVV7N8jBXAXnyrc+PsOF89O9AfVgGnbLxUtBb0clJ8y8ENMWLARGMI/1/SBRLz7u4HqxLgN71BJ17eono3wcjA==",
       "dependencies": {
         "@radix-ui/number": "1.1.0",
         "@radix-ui/primitive": "1.1.1",
@@ -3598,7 +3696,7 @@
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
         "@radix-ui/react-direction": "1.1.0",
-        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
         "@radix-ui/react-focus-guards": "1.1.1",
         "@radix-ui/react-focus-scope": "1.1.1",
         "@radix-ui/react-id": "1.1.0",
@@ -3611,8 +3709,34 @@
         "@radix-ui/react-use-layout-effect": "1.1.0",
         "@radix-ui/react-use-previous": "1.1.0",
         "@radix-ui/react-visually-hidden": "1.1.1",
-        "aria-hidden": "^1.1.1",
-        "react-remove-scroll": "^2.6.1"
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-select/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3784,15 +3908,14 @@
       }
     },
     "node_modules/@radix-ui/react-tooltip": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.6.tgz",
-      "integrity": "sha512-TLB5D8QLExS1uDn7+wH/bjEmRurNMTzNrtq7IjaS4kjion9NtzsTGkvR5+i7yc9q01Pi2KMM2cN3f8UG4IvvXA==",
-      "license": "MIT",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.1.7.tgz",
+      "integrity": "sha512-ss0s80BC0+g0+Zc53MvilcnTYSOi4mSuFWBPYPuTOFGjx+pUU+ZrmamMNwS56t8MTFlniA5ocjd4jYm/CdhbOg==",
       "dependencies": {
         "@radix-ui/primitive": "1.1.1",
         "@radix-ui/react-compose-refs": "1.1.1",
         "@radix-ui/react-context": "1.1.1",
-        "@radix-ui/react-dismissable-layer": "1.1.3",
+        "@radix-ui/react-dismissable-layer": "1.1.4",
         "@radix-ui/react-id": "1.1.0",
         "@radix-ui/react-popper": "1.2.1",
         "@radix-ui/react-portal": "1.1.3",
@@ -3801,6 +3924,32 @@
         "@radix-ui/react-slot": "1.1.1",
         "@radix-ui/react-use-controllable-state": "1.1.0",
         "@radix-ui/react-visually-hidden": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-tooltip/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.4.tgz",
+      "integrity": "sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.1",
+        "@radix-ui/react-compose-refs": "1.1.1",
+        "@radix-ui/react-primitive": "2.0.1",
+        "@radix-ui/react-use-callback-ref": "1.1.0",
+        "@radix-ui/react-use-escape-keydown": "1.1.0"
       },
       "peerDependencies": {
         "@types/react": "*",
@@ -3902,7 +4051,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.0.tgz",
       "integrity": "sha512-0Fmkebhr6PiseyZlYAOtLS+nb7jLmpqTrJyv61Pe68MKYW6OWdRE2kI70TaYY27u7H0lajqM3hSMMLFq18Z7nQ==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/rect": "1.1.0"
       },
@@ -3938,7 +4086,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.1.1.tgz",
       "integrity": "sha512-vVfA2IZ9q/J+gEamvj761Oq1FpWgCDaNOOIfbPVp2MVPLEomUr5+Vf7kJGwQ24YxZSlQVar7Bes8kyTo5Dshpg==",
-      "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.0.1"
       },
@@ -3960,8 +4107,7 @@
     "node_modules/@radix-ui/rect": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.0.tgz",
-      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg==",
-      "license": "MIT"
+      "integrity": "sha512-A9+lCBZoaMJlVKcRBz2YByCG+Cp2t6nAnMnNba+XiWxnj6r4JUFqfsgwocMBZU9LPtdxC6wB56ySYpc7LQIoJg=="
     },
     "node_modules/@react-aria/breadcrumbs": {
       "version": "3.5.20",
@@ -15361,10 +15507,9 @@
       }
     },
     "node_modules/sonner": {
-      "version": "1.7.2",
-      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.2.tgz",
-      "integrity": "sha512-zMbseqjrOzQD1a93lxahm+qMGxWovdMxBlkTbbnZdNqVLt4j+amF9PQxUCL32WfztOFt9t9ADYkejAL3jF9iNA==",
-      "license": "MIT",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/sonner/-/sonner-1.7.4.tgz",
+      "integrity": "sha512-DIS8z4PfJRbIyfVFDVnK9rO3eYDtse4Omcm6bt0oEr5/jtLgysmjuBl1frJ9E/EQZrFmKx2A8m/s5s9CRXIzhw==",
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0 || ^19.0.0-rc",
         "react-dom": "^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -17350,7 +17495,7 @@
       "version": "13.1.0-next",
       "license": "(EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0)",
       "dependencies": {
-        "@axonivy/jsonrpc": "~13.1.0-next.451",
+        "@axonivy/jsonrpc": "~13.1.0-next.502",
         "@axonivy/process-editor-inscription-protocol": "~13.1.0-next",
         "monaco-editor": "^0.44.0",
         "monaco-editor-workers": "^0.44.0",
@@ -17373,8 +17518,8 @@
       "dependencies": {
         "@axonivy/process-editor-inscription-core": "~13.1.0-next",
         "@axonivy/process-editor-inscription-protocol": "~13.1.0-next",
-        "@axonivy/ui-components": "~13.1.0-next.451",
-        "@axonivy/ui-icons": "~13.1.0-next.451",
+        "@axonivy/ui-components": "~13.1.0-next.502",
+        "@axonivy/ui-icons": "~13.1.0-next.502",
         "@monaco-editor/react": "^4.7.0-rc.0",
         "@radix-ui/react-dialog": "1.1.4",
         "@radix-ui/react-radio-group": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "publish:next": "lerna publish --exact --canary --preid next --pre-dist-tag next --no-git-tag-version --no-push --ignore-scripts --yes"
   },
   "devDependencies": {
-    "@axonivy/eslint-config": "~13.1.0-next.451",
+    "@axonivy/eslint-config": "~13.1.0-next.502",
     "@types/node": "^22.10.7",
     "lerna": "^8.1.9",
     "prettier": "^2.8.0",

--- a/packages/inscription-core/package.json
+++ b/packages/inscription-core/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "dependencies": {
-    "@axonivy/jsonrpc": "~13.1.0-next.451",
+    "@axonivy/jsonrpc": "~13.1.0-next.502",
     "@axonivy/process-editor-inscription-protocol": "~13.1.0-next",
     "monaco-editor": "^0.44.0",
     "monaco-editor-workers": "^0.44.0",

--- a/packages/inscription-view/package.json
+++ b/packages/inscription-view/package.json
@@ -16,8 +16,8 @@
   "dependencies": {
     "@axonivy/process-editor-inscription-core": "~13.1.0-next",
     "@axonivy/process-editor-inscription-protocol": "~13.1.0-next",
-    "@axonivy/ui-components": "~13.1.0-next.451",
-    "@axonivy/ui-icons": "~13.1.0-next.451",
+    "@axonivy/ui-components": "~13.1.0-next.502",
+    "@axonivy/ui-icons": "~13.1.0-next.502",
     "@monaco-editor/react": "^4.7.0-rc.0",
     "@radix-ui/react-dialog": "1.1.4",
     "@radix-ui/react-radio-group": "1.2.2",

--- a/packages/inscription-view/src/components/parts/common/customfield/CustomFieldTable.tsx
+++ b/packages/inscription-view/src/components/parts/common/customfield/CustomFieldTable.tsx
@@ -92,7 +92,6 @@ const CustomFieldTable = ({ data, onChange, type }: CustomFieldTableProps) => {
           removeRowAction
         ]
       : [];
-
   return (
     <PathCollapsible path='customFields' label='Custom Fields' defaultOpen={data.length > 0} controls={tableActions}>
       <div>

--- a/packages/inscription-view/src/components/parts/common/properties/PropertyTable.tsx
+++ b/packages/inscription-view/src/components/parts/common/properties/PropertyTable.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { ColumnDef, RowSelectionState, SortingState } from '@tanstack/react-table';
 import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from '@tanstack/react-table';
 import { Property } from './properties';
@@ -24,10 +24,7 @@ type PropertyTableProps = {
 const EMPTY_PROPERTY: Property = { expression: '', name: '' };
 
 export const PropertyTable = ({ properties, update, knownProperties, hideProperties, label, defaultOpen }: PropertyTableProps) => {
-  const [data, setData] = useState<Property[]>([]);
-  useEffect(() => {
-    setData(Property.of(properties));
-  }, [properties]);
+  const data = useMemo(() => Property.of(properties), [properties]);
 
   const onChange = (props: Property[]) => update(Property.to(props));
 

--- a/packages/inscription-view/src/components/parts/common/table/cellFocus-utils.ts
+++ b/packages/inscription-view/src/components/parts/common/table/cellFocus-utils.ts
@@ -1,0 +1,7 @@
+export const focusNewCell = (domTable: HTMLTableElement | undefined, rowIndex: number, cellType: 'input' | 'button') => {
+  setTimeout(() => {
+    if (!domTable) return;
+    const validRows = Array.from(domTable.rows).filter(row => !row.classList.contains('ui-message-row'));
+    validRows[rowIndex]?.cells[0]?.querySelector(cellType)?.focus();
+  }, 0);
+};

--- a/packages/inscription-view/src/components/parts/common/table/useResizableEditableTable.tsx
+++ b/packages/inscription-view/src/components/parts/common/table/useResizableEditableTable.tsx
@@ -5,6 +5,7 @@ import { deepEqual } from '../../../../utils/equals';
 import { IvyIcons } from '@axonivy/ui-icons';
 import { TableAddRow } from '@axonivy/ui-components';
 import type { FieldsetControl } from '../../../widgets/fieldset/fieldset-control';
+import { focusNewCell } from './cellFocus-utils';
 
 interface UseResizableEditableTableProps<TData> {
   data: TData[];
@@ -66,10 +67,13 @@ const useResizableEditableTable = <TData,>({
   });
 
   const addRow = () => {
+    const activeElement = document.activeElement;
+    const domTable = activeElement?.parentElement?.previousElementSibling?.getElementsByTagName('table')[0];
     const newData = [...tableData];
     newData.push(emptyDataObject);
     updateTableData(newData);
     setRowSelection({ [`${newData.length - 1}`]: true });
+    focusNewCell(domTable, newData.length, 'input');
   };
 
   const showAddButton = () => {

--- a/packages/inscription-view/src/components/parts/query/database/TableSort.tsx
+++ b/packages/inscription-view/src/components/parts/query/database/TableSort.tsx
@@ -19,6 +19,7 @@ import { useEditorContext } from '../../../../context/useEditorContext';
 import { useMeta } from '../../../../context/useMeta';
 import type { SelectItem } from '../../../widgets/select/Select';
 import { PathCollapsible } from '../../common/path/PathCollapsible';
+import { focusNewCell } from '../../common/table/cellFocus-utils';
 
 type OrderDirection = keyof typeof QUERY_ORDER;
 
@@ -34,13 +35,7 @@ export const TableSort = () => {
   const [data, setData] = useState<Column[]>([]);
 
   const { elementContext: context } = useEditorContext();
-  const columnItems = useMeta(
-    'meta/database/columns',
-    { context, database: config.query.dbName, table: config.query.sql.table },
-    []
-  ).data.map<SelectItem>(c => {
-    return { label: c.name, value: c.name };
-  });
+  const columnItems = useMeta('meta/database/columns', { context, database: config.query.dbName, table: config.query.sql.table }, []).data;
   const orderItems = useMemo<SelectItem[]>(() => Object.entries(QUERY_ORDER).map(([label, value]) => ({ label, value })), []);
 
   useEffect(() => {
@@ -61,7 +56,7 @@ export const TableSort = () => {
       {
         accessorKey: 'name',
         header: () => <span>Column</span>,
-        cell: cell => <SelectCell cell={cell} items={columnItems} />
+        cell: cell => <SelectCell cell={cell} items={columnItems.map(c => ({ label: c.name, value: c.name }))} />
       },
       {
         accessorKey: 'sorting',
@@ -132,10 +127,13 @@ export const TableSort = () => {
   };
 
   const addRow = () => {
+    const activeElement = document.activeElement;
+    const domTable = activeElement?.parentElement?.previousElementSibling?.getElementsByTagName('table')[0];
     const newData = [...data];
     newData.push(EMPTY_COLUMN);
     setData(newData);
     setRowSelection({ [`${newData.length - 1}`]: true });
+    focusNewCell(domTable, newData.length, 'button');
   };
 
   const updateOrder = (moveId: string, targetId: string) => {

--- a/packages/inscription-view/src/components/parts/rest/rest-request/rest-body/RestForm.tsx
+++ b/packages/inscription-view/src/components/parts/rest/rest-request/rest-body/RestForm.tsx
@@ -13,6 +13,7 @@ import { PathContext } from '../../../../../context/usePath';
 import Fieldset from '../../../../widgets/fieldset/Fieldset';
 import { ValidationRow } from '../../../common/path/validation/ValidationRow';
 import { ScriptCell } from '../../../../widgets/table/cell/ScriptCell';
+import { focusNewCell } from '../../../common/table/cellFocus-utils';
 
 const EMPTY_PARAMETER: RestParam = { name: '', expression: '', known: false };
 
@@ -61,10 +62,13 @@ export const RestForm = () => {
   };
 
   const addRow = () => {
+    const activeElement = document.activeElement;
+    const domTable = activeElement?.parentElement?.previousElementSibling?.getElementsByTagName('table')[0];
     const newData = [...data];
     newData.push(EMPTY_PARAMETER);
     onChange(newData);
     setRowSelection({ [`${newData.length - 1}`]: true });
+    focusNewCell(domTable, newData.length, 'input');
   };
 
   const removeRow = (index: number) => {

--- a/packages/inscription-view/src/components/parts/rest/rest-request/rest-target/RestParameters.tsx
+++ b/packages/inscription-view/src/components/parts/rest/rest-request/rest-target/RestParameters.tsx
@@ -22,6 +22,7 @@ import type { SelectItem } from '../../../../widgets/select/Select';
 import { ScriptCell } from '../../../../widgets/table/cell/ScriptCell';
 import { PathCollapsible } from '../../../common/path/PathCollapsible';
 import { ValidationRow } from '../../../common/path/validation/ValidationRow';
+import { focusNewCell } from '../../../common/table/cellFocus-utils';
 
 const EMPTY_PARAMETER: Parameter = { kind: 'Query', name: '', expression: '', known: false };
 
@@ -79,10 +80,13 @@ export const RestParameters = () => {
   };
 
   const addRow = () => {
+    const activeElement = document.activeElement;
+    const domTable = activeElement?.parentElement?.previousElementSibling?.getElementsByTagName('table')[0];
     const newData = [...data];
     newData.push(EMPTY_PARAMETER);
     onChange(newData);
     setRowSelection({ [`${newData.length - 1}`]: true });
+    focusNewCell(domTable, newData.length, 'button');
   };
 
   const removeRow = (index: number) => {

--- a/packages/inscription-view/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
+++ b/packages/inscription-view/src/components/widgets/code-editor/SingleLineCodeEditor.tsx
@@ -5,6 +5,7 @@ import type { CodeEditorProps } from './CodeEditor';
 import { CodeEditor } from './CodeEditor';
 import { monacoAutoFocus } from './useCodeEditor';
 import type { BrowserType } from '../../browser/useBrowser';
+import { focusAdjacentTabIndexMonaco } from '../../../utils/focus';
 
 type EditorOptions = {
   editorOptions?: {
@@ -14,6 +15,8 @@ type EditorOptions = {
     enter?: () => void;
     tab?: () => void;
     escape?: () => void;
+    arrowDown?: () => void;
+    arrowUp?: () => void;
   };
   modifyAction?: (value: string) => string;
 };
@@ -50,7 +53,7 @@ export const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, ke
           triggerAcceptSuggestion(editor);
         } else {
           if (editor.hasTextFocus() && document.activeElement instanceof HTMLElement) {
-            document.activeElement.blur();
+            focusAdjacentTabIndexMonaco('next');
           }
           if (keyActions?.tab) {
             keyActions.tab();
@@ -60,9 +63,42 @@ export const SingleLineCodeEditor = ({ onChange, onMountFuncs, editorOptions, ke
       'singleLine'
     );
     editor.addCommand(
+      MonacoEditorUtil.KeyCode.DownArrow,
+      () => {
+        if (isSuggestWidgetOpen(editor)) {
+          editor.trigger(undefined, 'selectNextSuggestion', undefined);
+        } else if (keyActions?.arrowDown) {
+          keyActions.arrowDown();
+        }
+      },
+      'singleLine'
+    );
+    editor.addCommand(
+      MonacoEditorUtil.KeyCode.UpArrow,
+      () => {
+        if (isSuggestWidgetOpen(editor)) {
+          editor.trigger(undefined, 'selectPrevSuggestion', undefined);
+        } else if (keyActions?.arrowUp) {
+          keyActions.arrowUp();
+        }
+      },
+      'singleLine'
+    );
+    editor.addCommand(
+      MonacoEditorUtil.KeyCode.Shift | MonacoEditorUtil.KeyCode.Tab,
+      () => {
+        if (editor.hasTextFocus() && document.activeElement instanceof HTMLElement) {
+          focusAdjacentTabIndexMonaco('previous');
+        }
+      },
+      'singleLine'
+    );
+    editor.addCommand(
       MonacoEditorUtil.KeyCode.Escape,
       () => {
-        if (!isSuggestWidgetOpen(editor) && keyActions?.escape) {
+        if (isSuggestWidgetOpen(editor)) {
+          editor.trigger(undefined, 'hideSuggestWidget', undefined);
+        } else if (keyActions?.escape) {
           keyActions.escape();
         }
       },

--- a/packages/inscription-view/src/components/widgets/table/cell/CodeEditorCell.tsx
+++ b/packages/inscription-view/src/components/widgets/table/cell/CodeEditorCell.tsx
@@ -4,13 +4,14 @@ import { useEffect, useState } from 'react';
 import { useMonacoEditor } from '../../code-editor/useCodeEditor';
 import { useOnFocus } from '../../../browser/useOnFocus';
 import useMaximizedCodeEditor from '../../../browser/useMaximizedCodeEditor';
-import { Button } from '@axonivy/ui-components';
+import { Button, selectNextPreviousCell } from '@axonivy/ui-components';
 import { useBrowser, type BrowserType } from '../../../browser/useBrowser';
 import { usePath } from '../../../../context/usePath';
 import { MaximizedCodeEditorBrowser } from '../../../browser/MaximizedCodeEditorBrowser';
 import { SingleLineCodeEditor } from '../../code-editor/SingleLineCodeEditor';
 import Browser from '../../../browser/Browser';
 import Input from '../../input/Input';
+import { focusAdjacentTabIndexMonaco } from '../../../../utils/focus';
 
 type CodeEditorCellProps<TData> = {
   cell: CellContext<TData, string>;
@@ -49,13 +50,6 @@ export function CodeEditorCell<TData>({ cell, macro, type, browsers, placeholder
     }
   }, [cell.row, isFocusWithin]);
 
-  const activeElementBlur = () => {
-    const activeElement = document.activeElement;
-    if (activeElement instanceof HTMLElement) {
-      activeElement.blur();
-    }
-  };
-
   return (
     <div className='script-input' {...focusWithinProps} tabIndex={1}>
       {isFocusWithin || browser.open || maximizeState.isMaximizedCodeEditorOpen ? (
@@ -77,8 +71,18 @@ export function CodeEditorCell<TData>({ cell, macro, type, browsers, placeholder
                 {...focusValue}
                 context={{ type, location: path }}
                 keyActions={{
-                  enter: activeElementBlur,
-                  escape: activeElementBlur
+                  enter: () => focusAdjacentTabIndexMonaco('previous'),
+                  escape: () => focusAdjacentTabIndexMonaco('previous'),
+                  arrowDown: () => {
+                    if (document.activeElement) {
+                      selectNextPreviousCell(document.activeElement, cell, 1);
+                    }
+                  },
+                  arrowUp: () => {
+                    if (document.activeElement) {
+                      selectNextPreviousCell(document.activeElement, cell, -1);
+                    }
+                  }
                 }}
                 onMountFuncs={[setEditor]}
                 macro={macro}

--- a/packages/inscription-view/src/monaco/monaco-editor-util.ts
+++ b/packages/inscription-view/src/monaco/monaco-editor-util.ts
@@ -110,7 +110,10 @@ export namespace MonacoEditorUtil {
     Tab = 2,
     Enter = 3,
     Escape = 9,
-    F2 = 60
+    F2 = 60,
+    UpArrow = 16,
+    DownArrow = 18,
+    Shift = 1024
   }
 
   let monacoEditorReactApiPromise: Promise<MonacoEditorReactApi>;

--- a/packages/inscription-view/src/utils/focus.test.ts
+++ b/packages/inscription-view/src/utils/focus.test.ts
@@ -1,0 +1,48 @@
+import { describe, test, expect, beforeEach } from 'vitest';
+import { focusAdjacentTabIndexMonaco } from './focus';
+
+describe('focusAdjacentTabIndexMonaco', () => {
+  let input1: HTMLInputElement, input2: HTMLInputElement, button: HTMLButtonElement, div: HTMLDivElement;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <input type="text" id="input1" />
+      <button id="button">Click me</button>
+      <input type="text" id="input2" />
+      
+    <div tabindex="0" id="div1" />
+    `;
+
+    input1 = document.getElementById('input1') as HTMLInputElement;
+    button = document.getElementById('button') as HTMLButtonElement;
+    input2 = document.getElementById('input2') as HTMLInputElement;
+    div = document.getElementById('div1') as HTMLDivElement;
+  });
+
+  test('focus the next focusable element', () => {
+    input1.focus();
+    focusAdjacentTabIndexMonaco('next');
+    expect(document.activeElement).toBe(button);
+  });
+
+  test('focus the previous focusable element', () => {
+    input2.focus();
+    focusAdjacentTabIndexMonaco('previous');
+    expect(document.activeElement).toBe(input1);
+  });
+
+  test('do nothing if there is no active element', () => {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    focusAdjacentTabIndexMonaco('next');
+    expect(document.activeElement).not.toBe(input1);
+    expect(document.activeElement).not.toBe(button);
+  });
+
+  test('do nothing if there is no next or previous element', () => {
+    div.focus();
+    focusAdjacentTabIndexMonaco('next');
+    expect(document.activeElement).toBe(div);
+  });
+});

--- a/packages/inscription-view/src/utils/focus.ts
+++ b/packages/inscription-view/src/utils/focus.ts
@@ -1,0 +1,18 @@
+export const focusAdjacentTabIndexMonaco = (direction: 'next' | 'previous') => {
+  if (!(document.activeElement instanceof HTMLElement)) return;
+
+  const focusableElements = Array.from(
+    document.querySelectorAll<HTMLElement>('input, button, select, textarea, [tabindex]:not([tabindex="-1"])')
+  );
+
+  const currentElement = document.activeElement;
+  const currentIndex = focusableElements.indexOf(currentElement);
+  if (currentIndex === -1) return;
+
+  //For previous, we need to go back 2 steps to ensure to jump out of monaco editor
+  const nextElement = direction === 'next' ? focusableElements[currentIndex + 1] : focusableElements[currentIndex - 2];
+
+  if (nextElement) {
+    nextElement.focus();
+  }
+};


### PR DESCRIPTION
Added the following improvements:
- Improved tab-navigation in monaco (you are now able to tab out of monaco via tab or shift + tab)
- Change useEffect in Property table with useMemo
- Add focus inside first cell of new row after adding one
- Add Keydown/-up navigation to tables. It works fine for the following tables:
  - Document Table
  - ParameterTable
  - ConditoinTable
  - TableFields
  - TableSort
  - MailAttachmentPart
- For the following table the navigation does only work seemlessly if you do not edit something in the table. as soon as you change the input the focus gets lost (because of rendering that are triggert inside or from a parent-component). With a tab, the focus is in most cases again restored and you can navigate with the keyboard again in the table.
  - MappingTree
  - PropertyTable
  - CustomerfieldTable

I think this is a good first step towards making editable tables more accessible with the keyboard. However, I have not found a good solution to solve the above tables. Also, I still need to do the following:
- Add tests

  