### PR TITLE
Fix screenshot report

### DIFF
--- a/playwright/inscription-test-project/pom.xml
+++ b/playwright/inscription-test-project/pom.xml
@@ -53,6 +53,7 @@
                 <BASE_URL>${test.engine.url}</BASE_URL>
                 <TEST_APP>${engine.test.app}</TEST_APP>
                 <SCREENSHOT_DIR>${project.build.directory}</SCREENSHOT_DIR>
+                <REPORT_DIR>${project.build.directory}</REPORT_DIR>
               </environmentVariables>
               <successCodes>
                 <successCode>0</successCode>

--- a/playwright/playwright.config.ts
+++ b/playwright/playwright.config.ts
@@ -3,13 +3,14 @@ import { devices, defineConfig } from '@playwright/test';
 const STANDALONE_URL = process.env.CI ? 'http://localhost:4000' : 'http://localhost:3000';
 const VIEWER_URL = process.env.CI ? 'http://localhost:4001' : 'http://localhost:3001';
 const INSCRIPTION_URL = process.env.CI ? 'http://localhost:4003' : 'http://localhost:3003';
+const REPORT_DIR = process.env.REPORT_DIR ? `${process.env.REPORT_DIR}/` : '';
 
 export default defineConfig({
   timeout: 1000 * (process.env.CI ? 120 : 30),
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
-  reporter: process.env.CI ? [['./tests/custom-reporter.ts'], ['junit', { outputFile: 'report.xml' }], ['list']] : 'html',
+  reporter: process.env.CI ? [['./tests/custom-reporter.ts'], ['junit', { outputFile: `${REPORT_DIR}report.xml` }], ['list']] : 'html',
   use: {
     actionTimeout: 0,
     trace: 'retain-on-failure',

--- a/playwright/process-test-project/pom.xml
+++ b/playwright/process-test-project/pom.xml
@@ -52,6 +52,7 @@
                 <BASE_URL>${test.engine.url}</BASE_URL>
                 <TEST_APP>${engine.test.app}</TEST_APP>
                 <SCREENSHOT_DIR>${project.build.directory}</SCREENSHOT_DIR>
+                <REPORT_DIR>${project.build.directory}</REPORT_DIR>
               </environmentVariables>
               <successCodes>
                 <successCode>0</successCode>


### PR DESCRIPTION
Save report.xml to test project build directory. 
Otherwise the second screenshot build overrides the result of the first report.