### PR TITLE
XIVY-11869 Load mapping tree until recursion

### DIFF
--- a/packages/inscription-view/src/components/browser/attribute/AttributeBrowser.test.tsx
+++ b/packages/inscription-view/src/components/browser/attribute/AttributeBrowser.test.tsx
@@ -85,13 +85,13 @@ describe('AttributeBrowser', () => {
   test('render', async () => {
     renderBrowser();
     TableUtil.assertHeaders(['Attribute']);
-    await TableUtil.assertRowCount(4);
+    await TableUtil.assertRowCount(7);
   });
 
   test('render code location', async () => {
     renderBrowser({ location: 'something.code' });
     TableUtil.assertHeaders(['Attribute']);
-    await TableUtil.assertRowCount(7);
+    await TableUtil.assertRowCount(13);
   });
 
   test('accept', async () => {

--- a/packages/inscription-view/src/components/parts/common/mapping-tree/MappingPart.test.tsx
+++ b/packages/inscription-view/src/components/parts/common/mapping-tree/MappingPart.test.tsx
@@ -106,12 +106,12 @@ describe('MappingPart', () => {
 
   test('tree can expand / collapse', async () => {
     renderTree();
-    const treeExpander = screen.getByRole('button', { name: 'Collapse tree' });
+    const treeExpander = screen.getByRole('button', { name: 'Expand tree' });
     await userEvent.click(treeExpander);
-    assertTableRows([ATTRIBUTES, PARAMS]);
+    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER, NODE_STRING]);
 
     await userEvent.click(treeExpander);
-    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER]);
+    assertTableRows([ATTRIBUTES, PARAMS]);
   });
 
   test('tree row can expand / collapse', async () => {
@@ -120,7 +120,7 @@ describe('MappingPart', () => {
     await userEvent.click(rowExpander);
     assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER, NODE_STRING]);
     await userEvent.click(rowExpander);
-    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER, NODE_STRING]);
+    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER]);
   });
 
   test('tree will filter', async () => {
@@ -133,12 +133,12 @@ describe('MappingPart', () => {
     const searchInput = screen.getByPlaceholderText('Search');
     expect(searchInput).toHaveValue('');
 
-    await userEvent.type(searchInput, 'amo');
-    assertTableRows([ATTRIBUTES, PARAMS, NODE_NUMBER]);
+    await userEvent.type(searchInput, 'ail');
+    assertTableRows([ATTRIBUTES, PARAMS, USER, NODE_STRING]);
 
     await userEvent.click(toggleFilter);
     expect(screen.queryByPlaceholderText('Search')).not.toBeInTheDocument();
-    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER]);
+    assertTableRows([ATTRIBUTES, PARAMS, NODE_BOOLEAN, NODE_NUMBER, USER, NODE_STRING]);
 
     await userEvent.click(toggleFilter);
     expect(screen.getByPlaceholderText('Search')).toHaveValue('');

--- a/packages/inscription-view/src/components/parts/common/mapping-tree/MappingTree.tsx
+++ b/packages/inscription-view/src/components/parts/common/mapping-tree/MappingTree.tsx
@@ -25,6 +25,8 @@ type MappingTreeProps = MappingPartProps & {
 
 const MappingTree = ({ data, variableInfo, onChange, globalFilter, onlyInscribedFilter, browsers }: MappingTreeProps) => {
   const [tree, setTree] = useState<MappingTreeData[]>([]);
+  const [expanded, setExpanded] = useState<ExpandedState>({ 0: true });
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
 
   useEffect(() => {
     const treeData = MappingTreeData.of(variableInfo);
@@ -66,9 +68,6 @@ const MappingTree = ({ data, variableInfo, onChange, globalFilter, onlyInscribed
     [browsers, loadChildren]
   );
 
-  const [expanded, setExpanded] = useState<ExpandedState>(true);
-  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-
   const table = useReactTable({
     data: tree,
     columns: columns,
@@ -102,7 +101,19 @@ const MappingTree = ({ data, variableInfo, onChange, globalFilter, onlyInscribed
   });
 
   return (
-    <SearchTable search={globalFilter.active ? { value: globalFilter.filter, onChange: globalFilter.setFilter } : undefined}>
+    <SearchTable
+      search={
+        globalFilter.active
+          ? {
+              value: globalFilter.filter,
+              onChange: change => {
+                setExpanded(change.length > 0 ? true : { 0: true });
+                globalFilter.setFilter(change);
+              }
+            }
+          : undefined
+      }
+    >
       <TableResizableHeader headerGroups={table.getHeaderGroups()} onClick={() => setRowSelection({})} />
       <TableBody>
         {table.getRowModel().rows.map(row => (

--- a/packages/inscription-view/src/components/parts/common/mapping-tree/mapping-tree-data.test.ts
+++ b/packages/inscription-view/src/components/parts/common/mapping-tree/mapping-tree-data.test.ts
@@ -74,11 +74,13 @@ describe('MappingTreeData', () => {
         { attribute: 'amount', children: [], value: '', type: 'Number', simpleType: 'Number', isLoaded: true, description: '' },
         {
           attribute: 'requester',
-          children: [],
+          children: [
+            { attribute: 'email', children: [], value: '', type: 'String', simpleType: 'String', isLoaded: true, description: '' }
+          ],
           value: '',
           type: 'workflow.humantask.User',
           simpleType: 'User',
-          isLoaded: false,
+          isLoaded: true,
           description: ''
         }
       ],
@@ -116,18 +118,6 @@ describe('MappingTreeData', () => {
 
   test('of', () => {
     expect(MappingTreeData.of(variableInfo)).toEqual(tree);
-  });
-
-  test('of with lazy loading', () => {
-    const treeData = MappingTreeData.of(variableInfo);
-    MappingTreeData.loadChildrenFor(variableInfo, 'workflow.humantask.User', treeData);
-
-    const expectTree = cloneObject(tree);
-
-    expectTree[0].children[2].isLoaded = true;
-    expectTree[0].children[2].children = [email_node];
-
-    expect(treeData).toEqual(expectTree);
   });
 
   test('of endless', () => {


### PR DESCRIPTION
On the mapping tree and the attribute browser, all children are loaded until a recursion occurs. 
This enables that it is possible to directly search after such children and it is not needed to expand rows first to trigger a loading.