### PR TITLE
Fix ui-exension error in log

### DIFF
--- a/packages/editor/src/accessibility/di.config.ts
+++ b/packages/editor/src/accessibility/di.config.ts
@@ -101,8 +101,6 @@ function configureElementNavigationTool(context: BindingContext) {
 }
 
 export function configureToastTool(context: BindingContext): void {
-  bindAsService(context, TYPES.IUIExtension, IvyToast);
-  context.bind(TYPES.IDiagramStartup).toService(IvyToast);
   configureActionHandler(context, ShowToastMessageAction.KIND, IvyToast);
   configureActionHandler(context, HideToastAction.KIND, IvyToast);
 }


### PR DESCRIPTION
Tooltip is no longer a UIExtension

![image](https://github.com/user-attachments/assets/414762dd-ad8b-4f41-85d2-51983aa90714)
